### PR TITLE
Stop state files from being truncated mid-write

### DIFF
--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -31,9 +31,31 @@ Anything written into memory, session history, or prompt inputs can be replayed 
 
 Built-in skills live in `jenny/skills/` (markdown + YAML frontmatter format). Agent capabilities that are "know-how" rather than code should be added as skills, not hardcoded into the agent loop. External skills can be published to and installed from ClawHub.
 
-## Atomic Session Writes
+## Atomic writes: one helper, `utils/path.py::atomic_write`
 
-`agent/memory.py` writes `history.jsonl` atomically (temp file + fsync + rename + directory fsync). This guarantees durability across crashes. Do not replace this with a plain `open(..., "w")` write.
+Any write that replaces a **whole file of state Jenny reads back herself** — cursors,
+skills, wiki entries, manifests, snapshot blobs, config — goes through
+`jenny/utils/path.py::atomic_write` (unique temp file + fsync + rename + tolerant directory
+fsync). Android kills processes freely, so a plain `write_text`/`open(..., "w")` leaves a
+*visible* truncated file: a skill whose frontmatter no longer parses, a cursor that reads
+back as 0, an unreadable manifest.
+
+Two things that keep going wrong here, both already fixed once:
+
+- **Do not hand-roll temp-file + `os.replace`.** Five places had done it, each subtly
+  different and every one of them missing the `fsync` — atomic against a killed process,
+  but not against power loss. If you need different behaviour, add a keyword argument to
+  the helper; do not write a sixth copy.
+- **Orphan temps are hidden, not absent.** A process killed mid-write leaves
+  `name.ext.<hex>.tmp` behind for good; `*.tmp` is in `_DEFAULT_INTERNAL_PATTERNS`
+  (`webui/workspace_files.py`) so the file browser does not offer it next to the real file.
+
+The exception is deliberate: the agent's own file tools (`tools/filesystem.py`,
+`apply_patch.py`, `python_exec_builtins.py`) write the *user's* files, where the write is
+the requested effect and replacing the inode would change semantics (`apply_patch` keeps
+`newline=""`, permissions and hardlinks must survive). Appends (`history.jsonl`,
+transcripts, app collections, the cron action log) are a different failure mode — a partial
+trailing line, which every reader already skips — and are not atomic-write candidates.
 
 ## Android WebView search/fetch
 

--- a/jenny/agent/memory.py
+++ b/jenny/agent/memory.py
@@ -318,7 +318,11 @@ class MemoryStore:
         return 0
 
     def set_last_dream_cursor(self, cursor: int) -> None:
-        self._dream_cursor_file.write_text(str(cursor), encoding="utf-8")
+        # Stesso helper del cursore di history (vedi ``append``): un
+        # write_text nudo qui lascerebbe, se il processo muore a metà, un file
+        # vuoto o parziale — cioè un cursore che ``get_last_dream_cursor``
+        # legge come 0 e Dream ricomincia da capo su tutta la storia.
+        atomic_write(self._dream_cursor_file, str(cursor))
 
     def build_dream_prompt(self, *, max_entries: int = 20) -> tuple[str, int] | None:
         """Build the Dream prompt with unprocessed history context.

--- a/jenny/agent/skills.py
+++ b/jenny/agent/skills.py
@@ -6,6 +6,8 @@ import re
 import shutil
 from pathlib import Path
 
+from jenny.utils.path import atomic_write
+
 _ANDROID_SKILL_NOTE = (
     "\n\n[Platform compatibility note: Android is the only supported runtime. "
     "There is no shell, no pip, and no CLI tools; use python_exec as the only "
@@ -263,7 +265,10 @@ class SkillsLoader:
         else:
             import json
             frontmatter = json.dumps(meta, indent=2)
-        skill_path.write_text(f"---\n{frontmatter}---\n{body}", encoding="utf-8")
+        # Scrittura piena del file della skill: un processo ucciso a metà
+        # lascerebbe un SKILL.md troncato — frontmatter a metà, quindi una skill
+        # che non si carica più. Da qui l'helper unico invece di write_text.
+        atomic_write(skill_path, f"---\n{frontmatter}---\n{body}")
 
     def delete_skill(self, name: str) -> None:
         """Delete a workspace skill directory.

--- a/jenny/agent/tools/download.py
+++ b/jenny/agent/tools/download.py
@@ -16,7 +16,6 @@ direttamente come i provider.
 from __future__ import annotations
 
 import mimetypes
-import os
 import re
 import uuid
 from pathlib import Path
@@ -31,6 +30,7 @@ from jenny.agent.tools.schema import StringSchema, tool_parameters_schema
 from jenny.security.network import validate_url_target
 from jenny.security.workspace_policy import _safe_expanduser
 from jenny.utils.helpers import detect_image_mime, ensure_dir, safe_filename
+from jenny.utils.path import atomic_write
 
 # Limiti operativi.
 TIMEOUT_S = 60.0
@@ -190,12 +190,9 @@ class DownloadFileTool(Tool):
 
         downloads_dir = ensure_dir(self._workspace / DOWNLOADS_SUBDIR)
         target = _unique_path(downloads_dir, name)
-        tmp = downloads_dir / f".{target.name}.{uuid.uuid4().hex}.tmp"
         try:
-            tmp.write_bytes(data)
-            os.replace(tmp, target)
+            atomic_write(target, data)
         except OSError as e:
-            tmp.unlink(missing_ok=True)
             return f"Error: could not save file: {e}"
 
         mime = (

--- a/jenny/snapshot/store.py
+++ b/jenny/snapshot/store.py
@@ -7,10 +7,10 @@ alla lettura. La deduplica è implicita (stesso contenuto → stesso path).
 from __future__ import annotations
 
 import hashlib
-import os
-import uuid
 import zlib
 from pathlib import Path
+
+from jenny.utils.path import atomic_write
 
 
 class BlobCorruptError(Exception):
@@ -30,26 +30,26 @@ def object_path(objects_dir: Path, hash_hex: str) -> Path:
 def put_blob(objects_dir: Path, content: bytes) -> str:
     """Scrive il blob se assente e ritorna il suo hash.
 
-    La scrittura passa da un file temporaneo + ``os.replace`` così un crash a
-    metà non lascia mai un blob parziale con il nome definitivo.
+    La scrittura è atomica, così un crash a metà non lascia mai un blob
+    parziale con il nome definitivo.
     """
     hash_hex = hash_content(content)
     dest = object_path(objects_dir, hash_hex)
     if dest.is_file():
         return hash_hex
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    # Nome tmp unico per chiamata: due scrittori concorrenti dello stesso blob
-    # non condividono mai il temporaneo, altrimenti l'``os.replace`` del primo
-    # porta via l'inode mentre il secondo ci sta ancora scrivendo (blob troncato
-    # o FileNotFoundError). Stessa scelta di ``atomic_write``.
-    tmp = dest.with_name(f"{dest.name}.{uuid.uuid4().hex}.tmp")
-    try:
-        tmp.write_bytes(zlib.compress(content))
-        os.replace(tmp, dest)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
+    # ``atomic_write`` per il temporaneo con nome unico (due scrittori dello
+    # stesso blob non se lo portano via a vicenda), il rename atomico e la
+    # pulizia; il suo suffisso ``.tmp`` è già filtrato da ``iter_blob_hashes``.
+    #
+    # Senza fsync, e non per distrazione: questo è l'unico punto sulla strada
+    # calda — ``put_blob`` viene chiamato una volta per file tracciato a ogni
+    # snapshot. Misurato sul Titan 2 (f2fs, ``fsync_mode=nobarrier``): ~4 ms per
+    # fsync, cioè secondi interi su un workspace di qualche migliaio di file. Il
+    # rename resta atomico, quindi un processo ucciso non lascia mai un blob
+    # parziale col nome definitivo; a cadere è solo la garanzia contro la
+    # perdita di corrente, che è dove stava anche prima di questa modifica.
+    atomic_write(dest, zlib.compress(content), fsync_file=False, fsync_dir=False)
     return hash_hex
 
 

--- a/jenny/utils/helpers.py
+++ b/jenny/utils/helpers.py
@@ -5,7 +5,6 @@ import json
 import re
 import shutil
 import time
-import uuid
 from contextlib import suppress
 from datetime import datetime, tzinfo
 from datetime import timezone as dt_timezone
@@ -14,6 +13,8 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from loguru import logger
+
+from jenny.utils.path import atomic_write
 
 
 def strip_think(text: str) -> str:
@@ -458,16 +459,6 @@ def _cleanup_tool_result_buckets(root: Path, current_bucket: Path) -> None:
         shutil.rmtree(path, ignore_errors=True)
 
 
-def _write_text_atomic(path: Path, content: str) -> None:
-    tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
-    try:
-        tmp.write_text(content, encoding="utf-8")
-        tmp.replace(path)
-    finally:
-        if tmp.exists():
-            tmp.unlink(missing_ok=True)
-
-
 def maybe_persist_tool_result(
     workspace: Path | None,
     session_key: str | None,
@@ -504,9 +495,9 @@ def maybe_persist_tool_result(
     path = bucket / f"{safe_filename(tool_call_id)}.{suffix}"
     if not path.exists():
         if suffix == "json" and isinstance(content, list):
-            _write_text_atomic(path, json.dumps(content, ensure_ascii=False, indent=2))
+            atomic_write(path, json.dumps(content, ensure_ascii=False, indent=2))
         else:
-            _write_text_atomic(path, text_payload)
+            atomic_write(path, text_payload)
 
     preview = text_payload[:_TOOL_RESULT_PREVIEW_CHARS]
     return _render_tool_result_reference(

--- a/jenny/webui/media_ingest.py
+++ b/jenny/webui/media_ingest.py
@@ -14,8 +14,6 @@ direttamente come i provider e ``apps/http.py``.
 from __future__ import annotations
 
 import hashlib
-import os
-import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -24,6 +22,7 @@ import httpx
 
 from jenny.security.network import validate_url_target
 from jenny.utils.helpers import detect_image_mime, ensure_dir
+from jenny.utils.path import atomic_write
 
 MediaDirProvider = Callable[[str | None], Path]
 
@@ -182,16 +181,10 @@ async def ingest_remote_image(
         return None
 
     target = remote_dir / f"{stem}{_MIME_EXT[mime]}"
-    tmp = remote_dir / f".{stem}.{uuid.uuid4().hex}.tmp"
     try:
-        tmp.write_bytes(data)
-        os.replace(tmp, target)
+        atomic_write(target, data)
     except OSError as exc:
         logger.warning("media ingest: failed to persist {}: {}", url, exc)
-        try:
-            tmp.unlink()
-        except OSError:
-            pass
         return None
 
     _enforce_remote_budget(remote_dir, logger=logger)

--- a/jenny/webui/transcript_store.py
+++ b/jenny/webui/transcript_store.py
@@ -12,7 +12,6 @@ import json
 import os
 import re
 import shutil
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -175,16 +174,10 @@ def _write_segment_manifest(session_key: str, segment_ids: list[str]) -> None:
         "segments": [_segment_manifest_entry(session_key, segment_id) for segment_id in segment_ids],
     }
     path = _webui_transcript_manifest_path(session_key)
-    # Nome tmp unico per chiamata: due scrittori concorrenti sullo stesso
-    # manifest non condividono il temporaneo (stessa scelta di ``atomic_write``).
-    # I tmp restano invisibili a ``_segment_ids_on_disk``, che filtra per regex.
-    tmp_path = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
-    try:
-        tmp_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        os.replace(tmp_path, path)
-    except BaseException:
-        tmp_path.unlink(missing_ok=True)
-        raise
+    # Il temporaneo di ``atomic_write`` ha nome unico per chiamata (due scrittori
+    # concorrenti sullo stesso manifest non se lo portano via a vicenda) e resta
+    # invisibile a ``_segment_ids_on_disk``, che filtra per regex.
+    atomic_write(path, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
 
 
 def _rebuild_segment_manifest(session_key: str) -> list[str]:

--- a/jenny/webui/wiki.py
+++ b/jenny/webui/wiki.py
@@ -23,6 +23,7 @@ from markdown import Markdown
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
+from jenny.utils.path import atomic_write
 from jenny.webui.audit import (
     AuditEntry,
     compute_anchor,
@@ -642,7 +643,7 @@ def create_audit(
         status="open",
         body=f"# Comment\n\n{comment.strip()}\n\n# Resolution\n\n<!-- filled in when the audit is processed -->\n",
     )
-    out_path.write_text(to_markdown(entry), "utf-8")
+    atomic_write(out_path, to_markdown(entry))
     return {
         "id": audit_id,
         "filename": filename,
@@ -681,7 +682,9 @@ def resolve_audit(wiki_root: Path, audit_id: str, resolution: str | None = None)
     entry.body = new_body
 
     resolved_path = resolved_dir / candidate.name
-    resolved_path.write_text(to_markdown(entry), "utf-8")
+    # Prima la copia risolta, poi la cancellazione dell'aperta: se il processo
+    # muore in mezzo resta un duplicato (recuperabile), non un audit perso.
+    atomic_write(resolved_path, to_markdown(entry))
     open_path.unlink()
     # Path relativi a wiki_root: non esporre il layout assoluto dell'host al
     # client (coerente con create_audit).

--- a/jenny/webui/workspace_files.py
+++ b/jenny/webui/workspace_files.py
@@ -19,8 +19,14 @@ from jenny.utils.path import atomic_write
 # possono comparire il backup ``config.json.bak`` e i temporanei di
 # ``atomic_write``, che contengono le stesse chiavi API e lo stesso secret.
 # Nascondere solo il nome esatto li avrebbe esposti nel browser file.
+#
+# ``*.tmp``: il temporaneo di ``atomic_write`` è invisibile solo per il tempo
+# di una scrittura, ma un processo ucciso in quel momento lo lascia lì per
+# sempre. È un residuo del runtime, non un file dell'utente, e mostrarlo
+# accanto all'originale invita solo ad aprire quello sbagliato.
 _DEFAULT_INTERNAL_PATTERNS = [
     ".*",
+    "*.tmp",
     "config.json*",
     "config.corrupt-*.json",
     "agent", "agent/**",

--- a/jenny/webui/workspace_files.py
+++ b/jenny/webui/workspace_files.py
@@ -8,6 +8,8 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
+from jenny.utils.path import atomic_write
+
 # Oltre ai dotfile, questi sono stato/implementazione del runtime (non
 # contenuto dell'utente): config.json contiene un secret e si edita dalle
 # Impostazioni, agent/ e ui/ sono bundle rigenerati ad ogni avvio, cron/ e
@@ -131,8 +133,10 @@ def read_file(path: Path, max_size: int = 1_000_000) -> str:
 
 def write_file(path: Path, content: str) -> None:
     """Write content to file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+    # Salvataggio dall'editor della WebUI: riscrive il file intero, quindi un
+    # processo ucciso a metà lo troncherebbe. Il contenuto vecchio resta valido
+    # fino al rename finale.
+    atomic_write(path, content)
 
 
 def create_directory(path: Path) -> None:

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -420,3 +420,21 @@ class TestDreamCursor:
         store.set_last_dream_cursor(3)
         store2 = MemoryStore(store.workspace)
         assert store2.get_last_dream_cursor() == 3
+
+    def test_failed_write_leaves_previous_cursor_readable(self, store, monkeypatch):
+        """La scrittura passa dall'helper atomico, non da un write_text nudo.
+
+        Con write_text, il file veniva troncato prima di fallire e il cursore
+        tornava 0: Dream ricominciava da capo su tutta la storia. Il raise finto
+        qui dimostra entrambe le cose — che l'helper è sulla strada, e che il
+        contenuto precedente sopravvive a una scrittura fallita.
+        """
+        store.set_last_dream_cursor(3)
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr("jenny.agent.memory.atomic_write", boom)
+        with pytest.raises(OSError):
+            store.set_last_dream_cursor(9)
+        assert store.get_last_dream_cursor() == 3

--- a/tests/agent/test_skills_loader.py
+++ b/tests/agent/test_skills_loader.py
@@ -385,3 +385,29 @@ def test_get_skill_metadata_handles_yaml_types(tmp_path: Path) -> None:
     assert meta.get("always") is True
     # metadata is a parsed dict, not a JSON string
     assert isinstance(meta.get("metadata"), dict)
+
+
+def test_update_skill_failed_write_leaves_the_skill_intact(tmp_path: Path) -> None:
+    """update_skill riscrive SKILL.md intero: deve farlo atomicamente.
+
+    Con un write_text nudo, un processo ucciso a metà lasciava un frontmatter
+    troncato — cioè una skill che non si carica più. Il raise finto dimostra sia
+    che l'helper atomico è sulla strada, sia che la versione precedente resta.
+    """
+    workspace = tmp_path / "ws"
+    ws_skills = workspace / "skills"
+    ws_skills.mkdir(parents=True)
+    skill_path = _write_skill(ws_skills, "alpha", body="# Alpha original")
+    before = skill_path.read_text(encoding="utf-8")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("no space left on device")
+
+    loader = SkillsLoader(workspace)
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("jenny.agent.skills.atomic_write", boom)
+        with pytest.raises(OSError):
+            loader.update_skill("alpha", description="new description")
+
+    assert skill_path.read_text(encoding="utf-8") == before
+    assert loader.load_skill("alpha") is not None

--- a/tests/webui/test_wiki_multi.py
+++ b/tests/webui/test_wiki_multi.py
@@ -448,6 +448,64 @@ class TestAudit:
         assert len(resolved_audits) == 1
         assert resolved_audits[0].status == "resolved"
 
+    def test_failed_write_leaves_no_half_written_audit(
+        self, wikis_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Una scrittura fallita non deve lasciare un audit troncato sul disco.
+
+        Un audit a metà è illeggibile da ``load_audits`` ma occupa il suo id: il
+        rename finale dell'helper atomico rende il file visibile solo completo.
+        """
+        wiki_root = _make_wiki(wikis_dir, "main", {"index.md": "# Home\ncontent here"})
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr("jenny.webui.wiki.atomic_write", boom)
+        with pytest.raises(OSError):
+            create_audit(
+                wiki_root=wiki_root,
+                target="index.md",
+                raw_markdown="# Home\ncontent here",
+                sel_start=8,
+                sel_end=15,
+                comment="typo",
+                severity="warn",
+                author="test",
+            )
+        assert load_audits(wiki_root, mode="all") == []
+
+    def test_failed_resolve_keeps_the_open_audit(
+        self, wikis_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Se la copia risolta non riesce, l'audit aperto resta dov'è.
+
+        ``resolve_audit`` scrive la copia *prima* di cancellare l'originale, così
+        il caso peggiore è un duplicato — mai un audit perso.
+        """
+        wiki_root = _make_wiki(wikis_dir, "main", {"index.md": "# Home\ncontent here"})
+        created = create_audit(
+            wiki_root=wiki_root,
+            target="index.md",
+            raw_markdown="# Home\ncontent here",
+            sel_start=8,
+            sel_end=15,
+            comment="typo",
+            severity="warn",
+            author="test",
+        )
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr("jenny.webui.wiki.atomic_write", boom)
+        with pytest.raises(OSError):
+            resolve_audit(wiki_root, created["id"], "fixed")
+
+        open_audits = load_audits(wiki_root, mode="open")
+        assert len(open_audits) == 1
+        assert load_audits(wiki_root, mode="resolved") == []
+
     def test_list_audits_mode_all(self, wikis_dir: Path):
         wiki_root = _make_wiki(wikis_dir, "main", {
             "index.md": "# Home\ncontent here",

--- a/tests/webui/test_workspace_routes.py
+++ b/tests/webui/test_workspace_routes.py
@@ -399,6 +399,32 @@ async def test_write_happy_path(
     assert (workspace_root / "new" / "note.txt").read_text(encoding="utf-8") == "ciao"
 
 
+async def test_write_that_fails_keeps_the_previous_content(
+    routes: WorkspaceRoutes, workspace_root: Path, config_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Salvare dall'editor riscrive il file intero: deve essere atomico.
+
+    Con un write_text nudo il vecchio contenuto era già perso nel momento in cui
+    la scrittura si interrompeva; con il rename finale il file resta quello di
+    prima finché il nuovo non è completo su disco.
+    """
+    target = workspace_root / "note.txt"
+    target.write_text("originale", encoding="utf-8")
+
+    def boom(*_args, **_kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr("jenny.webui.workspace_files.atomic_write", boom)
+    response = await routes.dispatch(
+        _request("/api/workspace/write", data={"path": "note.txt", "content": "nuovo"}),
+        "/api/workspace/write",
+    )
+    # 400 e non 500: la route mappa lì ogni OSError (comportamento preesistente).
+    assert response.status_code == 400
+    assert target.read_text(encoding="utf-8") == "originale"
+
+
 async def test_write_rejects_path_traversal(
     routes: WorkspaceRoutes, config_path: Path
 ) -> None:

--- a/tests/webui/test_workspace_routes.py
+++ b/tests/webui/test_workspace_routes.py
@@ -149,6 +149,8 @@ async def test_list_marks_default_runtime_dirs_internal_without_manifest(
     # vedrebbe nel browser senza developer mode.
     (workspace_root / "config.json.bak").write_text("{}", encoding="utf-8")
     (workspace_root / "config.corrupt-20260803T120000Z.json").write_text("x", encoding="utf-8")
+    # Residuo di un ``atomic_write`` interrotto: runtime, non contenuto utente.
+    (workspace_root / "note.txt.abc123.tmp").write_text("x", encoding="utf-8")
     (workspace_root / "agent").mkdir()
     (workspace_root / "agent" / "identity.md").write_text("x", encoding="utf-8")
     (workspace_root / "cron").mkdir()
@@ -163,6 +165,7 @@ async def test_list_marks_default_runtime_dirs_internal_without_manifest(
         "config.json": True,
         "config.json.bak": True,
         "config.corrupt-20260803T120000Z.json": True,
+        "note.txt.abc123.tmp": True,
         "agent": True,
         "cron": True,
         "sessions": True,


### PR DESCRIPTION
Fallout from the 0.3.2 audit: the config funnel fixed `config.json`, and a sweep for the
same defect class found it elsewhere. Nobody reported any of this.

Two commits, deliberately separate — the first is a correction, the second a simplification.

## Four state files could be left truncated

`skills.py`, the Dream cursor in `memory.py`, both audit writes in `wiki.py` and the WebUI
file editor still wrote with a plain `write_text`: no temp file, no rename. Android kills
processes freely, so an interrupted save left a *visible*, truncated file — a skill whose
frontmatter no longer parses, a Dream cursor that reads back as 0 and makes Dream reprocess
the whole history, an unreadable audit, or a workspace file the user had just edited.

`memory.py` is the clearest case: the history cursor twelve lines above already used
`atomic_write`, with a comment saying a bare `write_text` has no durability, and the Dream
cursor in the same module did exactly that.

Left alone on purpose: the agent's own file tools (`filesystem`, `apply_patch`,
`python_exec`) write the *user's* files, where the write is the requested effect and
replacing the inode would change semantics.

## One implementation instead of six

Five places had hand-rolled their own temp-file + `os.replace` — the tool result store, the
transcript manifest, the snapshot blob store, the download tool, media ingest — each a
slightly different copy of `utils/path.py::atomic_write`, every one missing the `fsync`.
They now call the helper: four temp-name schemes, four cleanup branches and an unused
private duplicate gone.

**One measured exception.** `put_blob` keeps `fsync` off, explicitly. It is the only one of
the five on a hot path — once per tracked file per snapshot — and fsync measured **~4 ms per
file** on the Titan 2's f2fs (200 files: 183 ms without, 993 ms with), which is seconds on a
workspace of a few thousand files. The rename stays atomic, so behaviour there is exactly
what it was; making the blob store durable against power loss wants one barrier per
snapshot, not one per blob, and that is a separate change.

The helper's temp file is not dot-prefixed, unlike the download/media-ingest copies, so a
killed process now leaves a visible orphan in a directory the user browses. `*.tmp` joins
the file browser's internal patterns, which also covers the orphans every existing
`atomic_write` already leaves behind.

## Verification

`ruff` clean, pyright 0 errors on the blocking subset, 3566 tests pass. Each new test fakes
a failing write, pinning two properties at once: that the helper is on the path, and that
the previous content survives. The snapshot, transcript, download and media suites pass
unmodified — the point of the second commit is that behaviour does not change.

Not verified on hardware, and worth saying: checking the file editor on the device needs
`installDebug`, which Android refuses over a release-signed install, so it would mean
uninstalling 0.3.2 and losing that workspace. Covered by a route-level test instead.

`.agent/gotchas.md` now states the rule rather than describing one instance of it.