### PR TITLE
Move CI off the Node version GitHub stopped supporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # fetch-depth: 0 — the check walks the PR commit range, which shallow
-      # clones do not contain.
-      - uses: actions/checkout@v4
+      # clones do not contain. Still needed on checkout v7: the default is
+      # depth 1, and v7's only behaviour change is blocking fork checkouts for
+      # pull_request_target / workflow_run, neither of which this workflow uses.
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check Signed-off-by on every commit
@@ -28,13 +30,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/setup-node@v4
+      # Node 24, not 20: Node 20 went end-of-life in April 2026. It only has to
+      # run the pinned pyright below, which is version-pinned separately.
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
       # CI validates the Android code path on a host runner; Android is the only supported runtime target.
       - run: pip install -e .
       - run: pip install ruff pytest pytest-asyncio
@@ -51,8 +55,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       # CI validates the Android code path on a host runner; Android is the only supported runtime target.


### PR DESCRIPTION
Every CI run carried the same warning: `checkout@v4`, `setup-node@v4` and
`setup-python@v5` declare Node 20, which GitHub deprecated and now force-runs on Node 24.
Two of them also pinned CI to a Node that reached end-of-life in April 2026.

All three go to their **current** major rather than to the first Node-24 release, because
the breaking changes are checkable and none of them apply here:

| action | breaking change | applies? |
|---|---|---|
| `checkout` v7 | blocks fork checkouts for `pull_request_target` / `workflow_run` | no — this workflow uses only `pull_request` and `push` |
| `setup-python` v7 | removes the `pip-install` input | no — never passed |
| `setup-node` v5 | automatic caching when `package.json` has a `packageManager` field | no — this repo has no `package.json`, and no `cache:` is passed |

`node-version` follows to 24. `fetch-depth: 0` stays on the `dco` job: checkout still
defaults to a depth of 1, and `check_dco.sh` walks the whole PR range.

The pyright pin is untouched — 1.1.411 runs on Node 26 locally, so 24 is not a risk.

## Why this is a PR and not a push

The `dco` job had **never executed once**: the repository had no `pull_request` runs in its
history, so nothing about it was actually tested. It ran for the first time on #4 — green in
6s, on `checkout@v4`. This PR is the same job on `checkout@v7`, which is the one thing about
this change that a local run cannot prove.