### PR TITLE
Skip the versionCode nobody could have taken

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -50,7 +50,13 @@ android {
         // versionCode must increase monotonically on every published build.
         // versionName tracks the Python package version in pyproject.toml —
         // keep the two in sync when releasing.
-        versionCode = 12
+        //
+        // Il 12 e' saltato di proposito: non e' mai stato pubblicato, ma tre APK
+        // diversi lo portano gia' (vedi l'avviso sull'albero sporco piu' sotto) e
+        // uno di quelli e' installato. Pubblicare a 12 avrebbe significato non
+        // poter provare l'aggiornamento proprio sul dispositivo che lo riceve:
+        // l'updater pretende un codice STRETTAMENTE maggiore di quello installato.
+        versionCode = 13
         versionName = "0.9.0"
 
         ndk {


### PR DESCRIPTION
## What this changes

Bumps `versionCode` from 12 to **13** for the 0.9.0 release. `versionName` stays `0.9.0`.

## Why this way

12 was never published — the latest manifest on GitHub is `version_code: 11` (0.8.0) — but it is
not free: three different APKs built on 25/08 all carry `0.9.0 / versionCode 12` (the builds that
prompted the dirty-tree warning in the same file), and one of them is the build currently installed
on the release device.

The updater compares `versionCode` and requires it to be **strictly higher** than the installed
one. Publishing 0.9.0 as 12 would therefore have meant the one phone this release exists to reach
could never be offered it — and the same integer would have named four different builds.

Skipping 12 publicly costs nothing: no device ever received it from GitHub, and a device at 11 is
offered 13 exactly as it would have been offered 12. The reason is recorded in a comment next to
the constant, where the next person will be standing when they wonder about the gap.

`release.py` is not used for this: the tree is already at 0.9.0, so its bump path correctly
refuses (`version 0.9.0 does not go up from 0.9.0`). The manifest step is `--manifest-only`, which
reuses the versionCode found in the tree — 13.

## How you verified it

```bash
ruff check jenny/ tests/          # clean
pytest -q tests/scripts/          # 38 passed
```

Confirmed against the published manifest and the device:

```
releases/latest/download/latest.json  →  version_code: 11, version_name: 0.8.0
adb dumpsys package                   →  versionCode=12  versionName=0.9.0
```

## Checklist

- [x] Every commit is signed off
- [x] `ruff check jenny/ tests/` is clean
- [x] `pytest -q` is green
- [x] New comments follow the language convention (Italian for new code)