### PR TITLE
Cut 0.9.5

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -56,8 +56,8 @@ android {
         // uno di quelli e' installato. Pubblicare a 12 avrebbe significato non
         // poter provare l'aggiornamento proprio sul dispositivo che lo riceve:
         // l'updater pretende un codice STRETTAMENTE maggiore di quello installato.
-        versionCode = 13
-        versionName = "0.9.0"
+        versionCode = 14
+        versionName = "0.9.5"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")

--- a/jenny/__init__.py
+++ b/jenny/__init__.py
@@ -25,7 +25,7 @@ def _resolve_version() -> str:
         # pyproject.toml né i metadata del pacchetto — quindi questo letterale
         # è la versione che l'app mostra davvero. Va tenuto allineato a
         # pyproject.toml: ci pensa tests/test_package_version.py.
-        return _read_pyproject_version() or "0.9.0"
+        return _read_pyproject_version() or "0.9.5"
 
 
 __version__ = _resolve_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jenny"
-version = "0.9.0"
+version = "0.9.5"
 description = "Jenny - AI agent framework (fork of nanobot)"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump only — `pyproject.toml`, `jenny/__init__.py`, `versionName` and
`versionCode` (13 → 14), written by `scripts/release.py 0.9.5`.

What ships in it is #13 (closes #11): the Commands chip, the New chat button,
`/clear` removed, a `/new` that clears the screen and really empties the model's
context, and a delete button on each project row.

Not a `.1`, because two things move for people who already have the app: `/clear`
no longer exists, and the chat reopens at the last `/new` separator — retroactively,
for transcripts that already contain one. Nothing is deleted; the previous session
loads by scrolling up. The updater's summary says so in both languages.