### PR TITLE
recall_history: a way back into the verbatim log

### DIFF
--- a/jenny/agent/tools/memory_recall.py
+++ b/jenny/agent/tools/memory_recall.py
@@ -33,6 +33,7 @@ perché rileggerli costi poco.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +42,7 @@ from loguru import logger
 from jenny.agent.memory_archive import ArchivedEntry, list_archived
 from jenny.agent.tools.base import Tool, tool_parameters
 from jenny.agent.tools.schema import ArraySchema, StringSchema, tool_parameters_schema
+from jenny.security.workspace_access import current_tool_workspace
 
 # Tetto dell'elenco, in caratteri. Non è il costo di un turno: è il costo di un
 # turno *in cui il modello ha deciso di cercare*, che è raro, quindi può essere
@@ -128,7 +130,9 @@ class MemoryRecallTool(Tool):
             "whenever a question is about the past — what was decided, what "
             "something used to be, why a thing was set up that way. "
             "The list is not filtered by keyword, so a fact stored in one "
-            "language is found by a question asked in another."
+            "language is found by a question asked in another. "
+            "This holds facts that were kept and later demoted; for the verbatim "
+            "wording of a turn, kept or not, use recall_history."
         )
 
     @property
@@ -197,4 +201,238 @@ class MemoryRecallTool(Tool):
         return f"{header}\n\n{body}"
 
 
-TOOLS = [MemoryRecallTool]
+
+
+# ---------------------------------------------------------------------------
+# Il verbale grezzo: history.jsonl
+# ---------------------------------------------------------------------------
+#
+# Perché serve un secondo tool e non basta ``recall``. Sono due popolazioni
+# diverse, e la differenza si misura sul telefono: l'archivio contiene **fatti
+# retrocessi** dai file di identità (``source: USER.md``, ``demoted:`` nel
+# frontmatter), cioè roba che Dream ha guardato, giudicato degna e poi spostata
+# quando il file cresceva. ``history.jsonl`` è il verbale turno per turno, prima
+# di qualunque giudizio.
+#
+# E il pezzo che nessuno legge è il **secondo**, non il primo. Le voci oltre il
+# cursore di Dream finiscono già nel prompt di ogni turno
+# (``read_recent_history_for_prompt``, tetto a 50 voci / 8.000 token); misurato
+# il 29/08 erano 2 su 108. Le altre 106 stanno sotto il cursore: fuori dal
+# prompt, e non nell'archivio, perché l'archivio non raccoglie righe di
+# cronologia. Sono il verbale di ciò che è stato detto dopo che Dream ne ha
+# tratto una sintesi — ed è lì che vive il dettaglio che la sintesi ha perso.
+#
+# **Non cerca per parola, e non è una svista.** È la stessa ragione per cui non
+# lo fa ``recall``: questa memoria è bilingue, e una voce scritta in italiano è
+# invisibile a una domanda posta in inglese sotto ricerca testuale. Un falso
+# negativo qui si legge come "non l'ho mai saputo", che è la bugia precisa da
+# evitare. Quindi l'elenco torna intero e a scegliere è il modello.
+
+_HISTORY_ENTRY_MAX_CHARS = 12_000
+_HISTORY_SNIPPET_CHARS = 110
+
+
+def _read_history(memory_dir: Path) -> list[dict[str, Any]]:
+    """Legge ``history.jsonl``, dalla più recente alla più vecchia.
+
+    Lettore locale e non ``MemoryStore``: l'unico che quella classe espone è
+    ``read_recent_history_for_prompt``, che è sagomato per il blocco del prompt
+    (parte da un cursore, filtra per tipo di sessione, applica i suoi tetti).
+    Qui serve il file intero.
+
+    Una riga illeggibile si salta invece di far fallire la lettura: un file
+    append-only troncato a metà da uno spegnimento non deve nascondere le
+    centoquattro righe sane che lo precedono.
+    """
+    path = Path(memory_dir) / "history.jsonl"
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("history.jsonl illeggibile: {}", exc)
+        return []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict) and rec.get("content"):
+            out.append(rec)
+    out.sort(key=lambda r: r.get("cursor", 0), reverse=True)
+    return out
+
+
+def _history_index_line(rec: dict[str, Any]) -> str:
+    """Una riga per voce: il cursore per riaprirla, e abbastanza per riconoscerla."""
+    content = str(rec.get("content", "")).strip()
+    notes = [n.strip() for n in content.splitlines() if n.strip()]
+    head = notes[0] if notes else ""
+    head = head.lstrip("- ").strip()
+    if len(head) > _HISTORY_SNIPPET_CHARS:
+        head = head[: _HISTORY_SNIPPET_CHARS - 1].rstrip() + "…"
+    # Il conteggio delle altre note non è decorazione: tre quarti delle voci ne
+    # hanno più di una (74 su 108, misurate), quindi senza questo il modello
+    # crederebbe che la voce sia solo la sua prima riga.
+    extra = f" (+{len(notes) - 1})" if len(notes) > 1 else ""
+    return f"[{rec.get('cursor', '?')}] {rec.get('timestamp', '')} {head}{extra}"
+
+
+@tool_parameters(
+    tool_parameters_schema(
+        cursors=ArraySchema(
+            StringSchema("Cursor of an entry from the index, e.g. '120'"),
+            description="Open these entries in full. Omit to get the index.",
+        ),
+    )
+)
+class HistoryRecallTool(Tool):
+    """Elenca il verbale grezzo, e apre le voci che il modello ha riconosciuto."""
+
+    # Gli stessi di ``recall``, e per la stessa ragione: è lì che succede "ti
+    # ricordi quando…". A Dream non va — il suo prompt si è già dimostrato
+    # sensibile alla superficie aggiunta, e la cronologia ce l'ha in ingresso.
+    _scopes = {"core", "orchestrator"}
+
+    def __init__(self, workspace: str | Path):
+        self._root = Path(workspace)
+        self._memory_dir = self._root / "memory"
+
+    @classmethod
+    def create(cls, ctx: Any) -> Tool:
+        return cls(workspace=ctx.workspace)
+
+    @property
+    def name(self) -> str:
+        return "recall_history"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the verbatim turn-by-turn log of the personal conversation — what was "
+            "actually said, before Dream distilled it. Call it with no arguments to see the "
+            "index, one line per turn, then call it again with the cursors you want in full. "
+            "Use it when recall came back with nothing and the question is about a detail "
+            "rather than a fact: an exact number, the wording of a decision, what was tried "
+            "before. recall holds facts that were kept and later demoted from the identity "
+            "files; this holds everything, kept or not. "
+            "The index is not filtered by keyword, so an entry written in one language is "
+            "found by a question asked in another."
+        )
+
+    @property
+    def read_only(self) -> bool:
+        return True
+
+    async def execute(self, cursors: list[str] | None = None, **kwargs: Any) -> str:
+        if (refusal := self._project_refusal()) is not None:
+            return refusal
+        entries = _read_history(self._memory_dir)
+        if not entries:
+            return (
+                "The conversation log is empty: there is no history.jsonl yet, or it holds "
+                "no entries. Nothing was lost — there is simply nothing here to read."
+            )
+        if cursors:
+            return self._open(entries, cursors)
+        return self._list(entries)
+
+    def _project_refusal(self) -> str | None:
+        """Dentro un progetto questo tool tace, e lo dice.
+
+        Non è privacy — è lo stesso utente da entrambe le parti. È che una
+        sessione di progetto **scrive dentro il progetto**: pagine di wiki,
+        diario, file che restano e che a volte stanno in un repository pubblico.
+        ``recall`` può viaggiare perché restituisce fatti che Dream ha filtrato e
+        ritenuto durevoli; il verbale non è filtrato da niente, e comprende
+        quello che è stato detto di sfuggita.
+
+        È anche la direzione in cui il resto del codice si muove già: il ramo
+        progetto di ``read_recent_history_for_prompt`` toglie questa coda dal
+        prompt di un progetto, e la modifica al giardiniere del 23/08 le ha
+        tolto la metà personale per la stessa forma di problema.
+
+        Allargare dopo è una riga; restringere dopo è togliere qualcosa a cui ci
+        si è abituati.
+        """
+        scoped = current_tool_workspace(self._root).project_path
+        if scoped is None:
+            return None
+        try:
+            same = Path(scoped).resolve() == self._root.resolve()
+        except OSError:
+            same = False
+        if same:
+            return None
+        return (
+            "recall_history only reads the personal conversation, and this turn is scoped to "
+            "a project. Use recall for durable facts, or ask in the personal chat if the "
+            "exact wording matters."
+        )
+
+    def _open(self, entries: list[dict[str, Any]], cursors: list[str]) -> str:
+        wanted = [str(c).strip() for c in cursors if str(c).strip()]
+        by_cursor = {str(e.get("cursor")): e for e in entries}
+        parts: list[str] = []
+        used = 0
+        shown: list[str] = []
+        for c in wanted:
+            rec = by_cursor.get(c)
+            if rec is None:
+                continue
+            block = f"[{rec.get('cursor')}] {rec.get('timestamp', '')}\n{rec.get('content', '')}"
+            if used + len(block) > _HISTORY_ENTRY_MAX_CHARS:
+                parts.append(
+                    f"(stopped at {len(shown)} of {len(wanted)} entries: the rest would not "
+                    "fit in one answer — ask for fewer cursors)"
+                )
+                break
+            parts.append(block)
+            used += len(block)
+            shown.append(c)
+        missing = [c for c in wanted if c not in by_cursor]
+        if missing:
+            # Un cursore che non esiste si dice, non si ignora: restituire in
+            # silenzio "solo le altre" fa concludere che quella voce non c'è.
+            parts.append(
+                f"No entry has cursor {', '.join(missing)}. "
+                "Call recall_history with no arguments to see the current index."
+            )
+        return "\n\n".join(parts) if parts else "Nothing to show."
+
+    def _list(self, entries: list[dict[str, Any]]) -> str:
+        lines: list[str] = []
+        used = 0
+        for rec in entries:
+            line = _history_index_line(rec)
+            if used + len(line) + 1 > _INDEX_MAX_CHARS:
+                break
+            lines.append(line)
+            used += len(line) + 1
+
+        header = (
+            f"The conversation log holds {len(entries)} turns, newest first. "
+            "Each line is one turn: [cursor] timestamp, the first note, and how many more "
+            "it carries. Call recall_history again with the cursors you want in full."
+        )
+        if len(lines) < len(entries):
+            # Il taglio si dice, e si dice da che parte: le più vecchie sono
+            # quelle che cadono, ed è l'unica direzione in cui il taglio non
+            # nasconde ciò che si cercava di solito.
+            header += (
+                f" Only the {len(lines)} most recent fit here; {len(entries) - len(lines)} "
+                "older turns are not listed."
+            )
+        if used > _INDEX_MAX_CHARS * _INDEX_CROWDED_SHARE:
+            logger.info(
+                "recall_history: indice al {:.0%} del tetto ({} voci)",
+                used / _INDEX_MAX_CHARS, len(entries),
+            )
+        return header + "\n\n" + "\n".join(lines)
+
+
+TOOLS = [MemoryRecallTool, HistoryRecallTool]

--- a/tests/agent/tools/test_history_recall.py
+++ b/tests/agent/tools/test_history_recall.py
@@ -1,0 +1,176 @@
+"""``recall_history``: il verbale grezzo, e il confine che non attraversa.
+
+Perché esiste accanto a ``recall``: l'archivio contiene fatti *retrocessi* dai
+file di identità, cioè roba che Dream ha giudicato degna. ``history.jsonl`` è il
+verbale turno per turno, prima di qualunque giudizio — ed è la parte **sotto** il
+cursore di Dream che non legge nessuno, perché quella sopra finisce già nel
+prompt di ogni turno.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from jenny.agent.tools.memory_recall import (
+    _INDEX_MAX_CHARS,
+    HistoryRecallTool,
+    MemoryRecallTool,
+)
+from jenny.security.workspace_access import enter_workspace_scope
+
+
+@dataclass
+class _Scope:
+    """Scope minimale: ``enter_workspace_scope`` lo tratta come opaco."""
+
+    project_path: Path
+    restrict_to_workspace: bool = False
+    writable: bool = True
+
+
+def _workspace(tmp_path: Path, entries: list[dict]) -> Path:
+    mem = tmp_path / "memory"
+    mem.mkdir(parents=True, exist_ok=True)
+    (mem / "history.jsonl").write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in entries) + "\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _entry(cursor: int, content: str, ts: str = "2026-08-21 18:24") -> dict:
+    return {"cursor": cursor, "timestamp": ts, "content": content,
+            "session_key": "unified:default"}
+
+
+def _tool(root: Path) -> HistoryRecallTool:
+    return HistoryRecallTool(workspace=root)
+
+
+class TestIndice:
+    async def test_le_piu_recenti_per_prime(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(1, "- prima"), _entry(9, "- ultima")])
+        out = await _tool(root).execute()
+        assert out.index("[9]") < out.index("[1]")
+
+    async def test_una_riga_per_turno_col_cursore(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(120, "- [durable] Soglia acero: sotto 15%")])
+        out = await _tool(root).execute()
+        assert "[120]" in out
+        assert "Soglia acero" in out
+
+    async def test_dice_quante_altre_note_porta(self, tmp_path):
+        """Tre quarti delle voci vere hanno piu' di una nota (74 su 108, misurate).
+
+        Senza il conteggio, il modello crede che la voce sia solo la prima riga.
+        """
+        root = _workspace(tmp_path, [_entry(5, "- una\n- due\n- tre")])
+        out = await _tool(root).execute()
+        assert "(+2)" in out
+
+    async def test_una_nota_sola_non_porta_il_conteggio(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(5, "- una sola")])
+        assert "(+" not in await _tool(root).execute()
+
+    async def test_il_taglio_si_dice_e_cade_dalle_vecchie(self, tmp_path):
+        lunghe = [_entry(i, "- " + "x" * 200) for i in range(1, 400)]
+        root = _workspace(tmp_path, lunghe)
+        out = await _tool(root).execute()
+        assert "older turns are not listed" in out
+        assert len(out) < _INDEX_MAX_CHARS + 2_000
+        assert "[399]" in out          # la piu' recente resta
+        assert "[1] " not in out       # la piu' vecchia e' quella che cade
+
+
+class TestApertura:
+    async def test_apre_per_cursore(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(7, "- [durable] tutto il testo lungo")])
+        out = await _tool(root).execute(cursors=["7"])
+        assert "tutto il testo lungo" in out
+
+    async def test_un_cursore_che_non_esiste_si_dice(self, tmp_path):
+        """Restituire in silenzio "solo le altre" fa concludere che la voce non c'e'."""
+        root = _workspace(tmp_path, [_entry(7, "- c'e'")])
+        out = await _tool(root).execute(cursors=["7", "999"])
+        assert "c'e'" in out
+        assert "999" in out
+
+    async def test_troppe_voci_si_ferma_e_lo_dice(self, tmp_path):
+        grosse = [_entry(i, "- " + "y" * 5_000) for i in range(1, 8)]
+        root = _workspace(tmp_path, grosse)
+        out = await _tool(root).execute(cursors=[str(i) for i in range(1, 8)])
+        assert "stopped at" in out
+
+
+class TestFileDifficili:
+    async def test_niente_file(self, tmp_path):
+        (tmp_path / "memory").mkdir()
+        out = await _tool(tmp_path).execute()
+        assert "nothing here to read" in out
+
+    async def test_una_riga_rotta_non_nasconde_le_sane(self, tmp_path):
+        """Un append-only troncato da uno spegnimento non deve azzerare il resto."""
+        root = _workspace(tmp_path, [_entry(1, "- sana")])
+        p = root / "memory" / "history.jsonl"
+        p.write_text(p.read_text() + '{"cursor": 2, "conte\n', encoding="utf-8")
+        out = await _tool(root).execute()
+        assert "sana" in out
+
+
+class TestConfineDiProgetto:
+    async def test_dentro_un_progetto_tace(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(1, "- personale")])
+        progetto = tmp_path / "wikis" / "qualcosa"
+        progetto.mkdir(parents=True)
+        with enter_workspace_scope(_Scope(project_path=progetto)):
+            out = await _tool(root).execute()
+        assert "scoped to a project" in out
+        assert "personale" not in out
+
+    async def test_fuori_da_un_progetto_legge(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(1, "- personale")])
+        with enter_workspace_scope(_Scope(project_path=root)):
+            out = await _tool(root).execute()
+        assert "personale" in out
+
+    async def test_senza_scope_legge(self, tmp_path):
+        root = _workspace(tmp_path, [_entry(1, "- personale")])
+        assert "personale" in await _tool(root).execute()
+
+    async def test_anche_aprendo_un_cursore(self, tmp_path):
+        """Il confine vale sull'apertura come sull'elenco, non solo sulla vetrina."""
+        root = _workspace(tmp_path, [_entry(1, "- personale")])
+        progetto = tmp_path / "wikis" / "qualcosa"
+        progetto.mkdir(parents=True)
+        with enter_workspace_scope(_Scope(project_path=progetto)):
+            out = await _tool(root).execute(cursors=["1"])
+        assert "personale" not in out
+
+
+class TestAccantoARecall:
+    def test_gli_stessi_scope(self):
+        assert HistoryRecallTool._scopes == MemoryRecallTool._scopes == {"core", "orchestrator"}
+
+    def test_entrambi_in_sola_lettura(self, tmp_path):
+        assert _tool(tmp_path).read_only is True
+
+    def test_i_due_nomi_non_si_confondono(self, tmp_path):
+        assert _tool(tmp_path).name == "recall_history"
+
+    @pytest.mark.parametrize("attesa", ["verbatim", "recall holds facts"])
+    def test_la_descrizione_dice_quale_finestra_copre(self, tmp_path, attesa):
+        """Due popolazioni diverse: se le descrizioni non lo dicono, sceglie a caso."""
+        assert attesa in _tool(tmp_path).description
+
+    def test_anche_recall_dice_dove_finisce_il_suo(self, tmp_path):
+        """Il rimando e' nei due sensi, o il modello non sa che l'altro esiste."""
+        assert "recall_history" in MemoryRecallTool(workspace=tmp_path).description
+
+    def test_create_prende_la_radice(self):
+        t = HistoryRecallTool.create(SimpleNamespace(workspace="/tmp/radice"))
+        assert t._memory_dir == Path("/tmp/radice/memory")

--- a/tests/security/test_one_write_root.py
+++ b/tests/security/test_one_write_root.py
@@ -295,6 +295,11 @@ _NOT_A_WRITE_ROOT = {
     ),
     ("message.py", "project_path"): "risolve gli allegati in uscita: è una lettura",
     ("message.py", "allowed_root"): "idem — l'alias storico, non una seconda risposta",
+    ("memory_recall.py", "project_path"): (
+        "domanda opposta: non dove si scrive, ma **se** questo turno è dentro un "
+        "progetto. recall_history legge solo la radice e tace altrove, e il "
+        "confronto col workspace di radice è l'unico modo di accorgersene"
+    ),
 }
 
 


### PR DESCRIPTION
`memory/history.jsonl` is the turn-by-turn record of what was actually said. Entries past Dream's cursor already reach the model — `read_recent_history_for_prompt` puts them in every prompt, capped at 50 turns and 8,000 tokens. On the test device that was 2 entries of 108.

The other 106 sit below the cursor: out of the prompt, and not in the archive either, because the archive collects facts demoted from the identity files (`source:`, `demoted:` in the frontmatter), not lines of history. They are where a detail lives after Dream has distilled it away.

## Why it is not a search

`recall` deliberately does no substring matching: the memory is bilingual, and a note written in one language is invisible to a question asked in another — a false negative that reads exactly like "I never knew that". The same applies here, so `recall_history` takes the same shape: an index, one line per turn, then open the cursors you recognise.

The index line carries how many further notes the turn holds. Three quarters of real entries carry more than one (74 of 108 measured), so without that count the first line passes for the whole turn.

## Root only

Inside a project the tool says so and stops — on opening a cursor as well as on the index.

Not privacy; it is the same person on both sides. A project turn writes into the project — wiki pages, journal, files that stay, some of them in public repositories. `recall` can travel because it returns what Dream filtered and kept; the verbatim log is filtered by nothing. It is also the direction the rest of the code already points: the project branch of `read_recent_history_for_prompt` withholds this queue from a project's prompt, and the gardener change of 2026-08-23 took the personal half away for the same shape of reason.

Widening later is one line. Narrowing later takes something away.

## Verified on device

Asked for a past conclusion rather than a fact — the wording of something worked out weeks ago, where the code is still readable but the reasoning is not. The model ran `grep` over `memory/*.jsonl` first (count mode: a number, not the text), then `recall` (nothing), then the `recall_history` index, then opened the two cursors it recognised, and answered correctly.

Index cost on that device: 13,564 characters for 109 turns; opening two turns, 1,543.

## Known horizon

At ~124 characters per turn the 24,000-character cap fits roughly 193 turns; there are 109 today. Past that the header states how many older turns are not listed and the cut falls on the oldest — but that is the point where a second idea will be needed.

Reading `project_path` by hand is declared in the write-root guard with its reason: the question here is the opposite one — not where writing may go, but whether this turn is inside a project at all.

No version bump, no CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)