### PR TITLE
Retry a 404 on the versioned base before failing the turn

### DIFF
--- a/jenny/providers/openai_compat_helpers.py
+++ b/jenny/providers/openai_compat_helpers.py
@@ -9,9 +9,11 @@ il provider → nessun ciclo. Il provider re-importa i nomi che usa.
 from __future__ import annotations
 
 import json
+import re
 import secrets
 import string
 from typing import Any
+from urllib.parse import urlsplit
 
 from jenny.providers.body_merge import deep_merge
 from jenny.providers.endpoint_budget import (
@@ -207,6 +209,27 @@ def _is_direct_openai_base(api_base: str | None) -> bool:
         return True
     normalized = api_base.strip().lower().rstrip("/")
     return "api.openai.com" in normalized and "openrouter" not in normalized
+
+
+_VERSION_SEGMENT_RE = re.compile(r"^v\d+$")
+
+
+def _versioned_base_candidate(api_base: str | None) -> str | None:
+    """Ritorna ``<base>/v1`` se la base non porta già un segmento di versione.
+
+    Serve al recupero automatico dal 404: parecchi gateway OpenAI-compatibili
+    servono la lista modelli sulla radice ma le completions solo sotto ``/v1``,
+    quindi una base senza versione è una causa frequente di endpoint inesistente.
+    ``None`` quando la versione c'è già (o la base è vuota): lì un secondo
+    tentativo non avrebbe niente da correggere.
+    """
+    base = (api_base or "").strip().rstrip("/")
+    if not base:
+        return None
+    last_segment = urlsplit(base).path.rstrip("/").rsplit("/", 1)[-1]
+    if _VERSION_SEGMENT_RE.match(last_segment):
+        return None
+    return f"{base}/v1"
 
 
 def _responses_circuit_key(

--- a/jenny/providers/openai_compat_provider.py
+++ b/jenny/providers/openai_compat_provider.py
@@ -43,6 +43,7 @@ from jenny.providers.openai_compat_helpers import (
     _thinking_extra_body,
     _thinking_styles_for,
     _uses_openrouter_attribution,
+    _versioned_base_candidate,
     is_openai_reasoning_model,
 )
 from jenny.providers.openai_compat_parsing import ResponseParsingMixin
@@ -111,10 +112,13 @@ class OpenAICompatProvider(ResponseParsingMixin, LLMProvider):
         if self._http_client is None:
             self._build_http_client()
 
+    def _base_url(self) -> str:
+        """Base HTTP corrente, senza slash finale."""
+        return (self._effective_base or "https://api.openai.com/v1").rstrip("/")
+
     def _api_url(self, path: str) -> str:
         """Return a fully-qualified API URL for the httpx fallback."""
-        base = (self._effective_base or "https://api.openai.com/v1").rstrip("/")
-        return f"{base}{path}"
+        return f"{self._base_url()}{path}"
 
     def _auth_headers(self) -> dict[str, str]:
         """Return request headers for the httpx fallback."""
@@ -131,6 +135,47 @@ class OpenAICompatProvider(ResponseParsingMixin, LLMProvider):
             body = _deep_merge(body, extra_body)
         return body
 
+    async def _send_request(
+        self,
+        url: str,
+        body: dict[str, Any],
+        *,
+        stream: bool,
+    ) -> httpx.Response:
+        """POST singola su ``url``; propaga ``HTTPStatusError`` sugli status di errore."""
+        if self._http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+        request = self._http_client.build_request(
+            "POST", url,
+            headers=self._auth_headers(),
+            json=body,
+            timeout=_openai_compat_timeout_s(local=self._is_local),
+            params=self._extra_query or None,
+        )
+        response = await self._http_client.send(request, stream=stream)
+        response.raise_for_status()
+        return response
+
+    @staticmethod
+    async def _error_body_text(response: httpx.Response | None, *, stream: bool) -> str:
+        """Corpo della risposta di errore, letto anche quando la richiesta era in streaming."""
+        if response is None:
+            return ""
+        try:
+            if stream and not response.is_closed:
+                await response.aread()
+            return response.text
+        except Exception:
+            return ""
+
+    @staticmethod
+    async def _release(response: httpx.Response | None) -> None:
+        """Chiude una risposta di errore prima di riprovare, per non trattenere la connessione."""
+        if response is None:
+            return
+        with suppress(Exception):
+            await response.aclose()
+
     async def _http_request(
         self,
         path: str,
@@ -138,30 +183,65 @@ class OpenAICompatProvider(ResponseParsingMixin, LLMProvider):
         *,
         stream: bool = False,
     ) -> httpx.Response:
-        """Send a POST request on the httpx client."""
+        """Send a POST request on the httpx client.
+
+        Su 404 ritenta **una sola volta** con ``<base>/v1`` quando la base
+        configurata non porta già un segmento di versione: è il caso dei gateway
+        che espongono ``/models`` sulla radice ma le completions solo sotto
+        ``/v1``, dove la lista modelli si popola e poi ogni turno fallisce. Se il
+        secondo tentativo passa, la base corretta resta valida per il processo;
+        se fallisce anche quello l'errore nomina entrambi gli URL provati, così
+        chi legge sa che a essere sbagliata è la base e non la chiave.
+        """
         await self._ensure_client()
-        if self._http_client is None:
-            raise RuntimeError("HTTP client not initialized")
         url = self._api_url(path)
-        headers = self._auth_headers()
-        timeout = _openai_compat_timeout_s(local=self._is_local)
-        request = self._http_client.build_request(
-            "POST", url, headers=headers, json=body, timeout=timeout,
-            params=self._extra_query or None,
-        )
-        response = await self._http_client.send(request, stream=stream)
         try:
-            response.raise_for_status()
+            return await self._send_request(url, body, stream=stream)
         except httpx.HTTPStatusError as e:
-            try:
-                if stream and not e.response.is_closed:
-                    await e.response.aread()
-                text = e.response.text if e.response else ""
-            except Exception:
-                text = ""
-            raise RuntimeError(
-                f"HTTP {e.response.status_code}: {text[:500]}"
-            ) from e
+            status = e.response.status_code if e.response is not None else 0
+            candidate = _versioned_base_candidate(self._base_url()) if status == 404 else None
+            if candidate is None:
+                text = await self._error_body_text(e.response, stream=stream)
+                raise RuntimeError(f"HTTP {status} from {url}: {text[:500]}") from e
+            await self._release(e.response)
+            return await self._retry_on_versioned_base(
+                path, body, failed_url=url, base=candidate, stream=stream,
+            )
+
+    async def _retry_on_versioned_base(
+        self,
+        path: str,
+        body: dict[str, Any],
+        *,
+        failed_url: str,
+        base: str,
+        stream: bool,
+    ) -> httpx.Response:
+        """Secondo e ultimo tentativo su ``base``, adottata solo se risponde."""
+        retry_url = f"{base}{path}"
+        logger.info("HTTP 404 from {} — retrying once on the versioned base {}", failed_url, retry_url)
+        try:
+            response = await self._send_request(retry_url, body, stream=stream)
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code if e.response is not None else 0
+            text = await self._error_body_text(e.response, stream=stream)
+            if status == 404:
+                raise RuntimeError(
+                    f"HTTP 404: no endpoint at {failed_url} nor at {retry_url}. "
+                    "The provider's API base URL looks wrong — check it in Settings. "
+                    f"Server said: {text[:300]}"
+                ) from e
+            # Uno status diverso dal 404 dice che l'endpoint c'è: la base
+            # versionata è quella giusta e va adottata anche se questa richiesta
+            # fallisce per altro (chiave, modello, quota). Senza, ogni turno
+            # ripagherebbe il tentativo a vuoto per poi fallire allo stesso modo.
+            self._effective_base = base
+            raise RuntimeError(f"HTTP {status} from {retry_url}: {text[:500]}") from e
+
+        logger.warning(
+            "API base URL auto-corrected for this run: {} -> {}", self._base_url(), base,
+        )
+        self._effective_base = base
         return response
 
     @classmethod

--- a/tests/providers/test_base_url_version_fallback.py
+++ b/tests/providers/test_base_url_version_fallback.py
@@ -1,0 +1,222 @@
+"""Recupero automatico da una base URL senza segmento di versione.
+
+Diversi gateway OpenAI-compatibili servono ``/models`` sulla radice ma le
+completions solo sotto ``/v1``: la lista modelli si popola, la base sembra
+valida, e poi ogni turno torna 404 (issue #18, Pollinations). Il provider
+ritenta una volta su ``<base>/v1`` e, se quello risponde, lo adotta.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from jenny.providers.openai_compat_helpers import _versioned_base_candidate
+from jenny.providers.openai_compat_provider import OpenAICompatProvider
+
+
+def _response(url: str, status: int, body: str = "") -> httpx.Response:
+    return httpx.Response(status, text=body, request=httpx.Request("POST", url))
+
+
+def _provider_with_replies(api_base: str, replies: dict[str, httpx.Response]):
+    """Provider il cui client finto risponde per URL; annota gli URL chiamati."""
+    calls: list[str] = []
+
+    def _build_request(method, url, **kwargs):
+        calls.append(url)
+        request = MagicMock()
+        request.url = url
+        return request
+
+    async def _send(request, **kwargs):
+        return replies[request.url]
+
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.build_request = MagicMock(side_effect=_build_request)
+    client.send = AsyncMock(side_effect=_send)
+
+    provider = OpenAICompatProvider(api_key="k", api_base=api_base, default_model="m")
+    provider._http_client = client
+    return provider, calls
+
+
+NOT_FOUND = '{"success":false,"error":{"message":"Oh no, there is nothing here."}}'
+
+
+class TestVersionedBaseCandidate:
+    """La regola pura: quando ha senso aggiungere /v1 e quando no."""
+
+    def test_bare_host_gets_v1(self) -> None:
+        assert _versioned_base_candidate("https://gen.pollinations.ai") == (
+            "https://gen.pollinations.ai/v1"
+        )
+
+    def test_trailing_slash_is_normalized(self) -> None:
+        assert _versioned_base_candidate("https://gen.pollinations.ai/") == (
+            "https://gen.pollinations.ai/v1"
+        )
+
+    def test_path_without_version_gets_v1(self) -> None:
+        assert _versioned_base_candidate("https://api.groq.com/openai") == (
+            "https://api.groq.com/openai/v1"
+        )
+
+    def test_existing_version_segment_is_left_alone(self) -> None:
+        assert _versioned_base_candidate("https://api.openai.com/v1") is None
+        assert _versioned_base_candidate("https://example.com/api/v3/") is None
+
+    def test_empty_base_has_no_candidate(self) -> None:
+        assert _versioned_base_candidate("") is None
+        assert _versioned_base_candidate(None) is None
+
+
+class TestRetryOnVersionedBase:
+    """Il comportamento end-to-end di _http_request."""
+
+    async def test_404_retries_on_v1_and_adopts_it(self) -> None:
+        provider, calls = _provider_with_replies(
+            "https://gen.pollinations.ai",
+            {
+                "https://gen.pollinations.ai/chat/completions": _response(
+                    "https://gen.pollinations.ai/chat/completions", 404, NOT_FOUND,
+                ),
+                "https://gen.pollinations.ai/v1/chat/completions": _response(
+                    "https://gen.pollinations.ai/v1/chat/completions", 200, "{}",
+                ),
+            },
+        )
+
+        response = await provider._http_request("/chat/completions", {})
+
+        assert response.status_code == 200
+        assert calls == [
+            "https://gen.pollinations.ai/chat/completions",
+            "https://gen.pollinations.ai/v1/chat/completions",
+        ]
+        assert provider._effective_base == "https://gen.pollinations.ai/v1"
+
+    async def test_correction_is_remembered_for_later_calls(self) -> None:
+        provider, calls = _provider_with_replies(
+            "https://gen.pollinations.ai",
+            {
+                "https://gen.pollinations.ai/chat/completions": _response(
+                    "https://gen.pollinations.ai/chat/completions", 404, NOT_FOUND,
+                ),
+                "https://gen.pollinations.ai/v1/chat/completions": _response(
+                    "https://gen.pollinations.ai/v1/chat/completions", 200, "{}",
+                ),
+            },
+        )
+
+        await provider._http_request("/chat/completions", {})
+        await provider._http_request("/chat/completions", {})
+
+        # Il secondo turno non ripaga il tentativo a vuoto.
+        assert calls[-1] == "https://gen.pollinations.ai/v1/chat/completions"
+        assert calls.count("https://gen.pollinations.ai/chat/completions") == 1
+
+    async def test_both_404_names_both_urls(self) -> None:
+        provider, calls = _provider_with_replies(
+            "https://wrong.example.com",
+            {
+                "https://wrong.example.com/chat/completions": _response(
+                    "https://wrong.example.com/chat/completions", 404, NOT_FOUND,
+                ),
+                "https://wrong.example.com/v1/chat/completions": _response(
+                    "https://wrong.example.com/v1/chat/completions", 404, NOT_FOUND,
+                ),
+            },
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await provider._http_request("/chat/completions", {})
+
+        message = str(excinfo.value)
+        assert "https://wrong.example.com/chat/completions" in message
+        assert "https://wrong.example.com/v1/chat/completions" in message
+        assert "base URL" in message
+        # La base sbagliata non viene adottata.
+        assert provider._effective_base == "https://wrong.example.com"
+        assert len(calls) == 2
+
+    async def test_versioned_base_does_not_retry(self) -> None:
+        provider, calls = _provider_with_replies(
+            "https://api.openai.com/v1",
+            {
+                "https://api.openai.com/v1/chat/completions": _response(
+                    "https://api.openai.com/v1/chat/completions", 404, NOT_FOUND,
+                ),
+            },
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await provider._http_request("/chat/completions", {})
+
+        assert len(calls) == 1
+        assert "https://api.openai.com/v1/chat/completions" in str(excinfo.value)
+
+    async def test_non_404_is_not_retried(self) -> None:
+        provider, calls = _provider_with_replies(
+            "https://gen.pollinations.ai",
+            {
+                "https://gen.pollinations.ai/chat/completions": _response(
+                    "https://gen.pollinations.ai/chat/completions",
+                    401,
+                    '{"error":"invalid api key"}',
+                ),
+            },
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await provider._http_request("/chat/completions", {})
+
+        message = str(excinfo.value)
+        assert "HTTP 401" in message
+        assert "invalid api key" in message
+        assert len(calls) == 1
+        assert provider._effective_base == "https://gen.pollinations.ai"
+
+    async def test_streaming_404_retries_too(self) -> None:
+        provider, calls = _provider_with_replies(
+            "https://gen.pollinations.ai",
+            {
+                "https://gen.pollinations.ai/chat/completions": _response(
+                    "https://gen.pollinations.ai/chat/completions", 404, NOT_FOUND,
+                ),
+                "https://gen.pollinations.ai/v1/chat/completions": _response(
+                    "https://gen.pollinations.ai/v1/chat/completions", 200, "{}",
+                ),
+            },
+        )
+
+        response = await provider._http_request("/chat/completions", {}, stream=True)
+
+        assert response.status_code == 200
+        assert len(calls) == 2
+
+    async def test_non_404_on_retry_adopts_the_versioned_base(self) -> None:
+        """401 sul /v1 significa che l'endpoint c'è: la base è giusta, la chiave no."""
+        provider, calls = _provider_with_replies(
+            "https://gen.pollinations.ai",
+            {
+                "https://gen.pollinations.ai/chat/completions": _response(
+                    "https://gen.pollinations.ai/chat/completions", 404, NOT_FOUND,
+                ),
+                "https://gen.pollinations.ai/v1/chat/completions": _response(
+                    "https://gen.pollinations.ai/v1/chat/completions",
+                    401,
+                    '{"error":"API key required"}',
+                ),
+            },
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await provider._http_request("/chat/completions", {})
+
+        assert "HTTP 401" in str(excinfo.value)
+        assert "API key required" in str(excinfo.value)
+        assert provider._effective_base == "https://gen.pollinations.ai/v1"
+        assert len(calls) == 2


### PR DESCRIPTION
Closes #18.

## The trap

A provider base URL without a version segment fails in a way the app helps the user reach. The Settings model probe asks `<base>/models`, and several OpenAI-compatible gateways answer that on the root while serving completions only under `/v1`. So the picker fills with real models, the base reads as confirmed, and then every turn returns 404 with an opaque provider body.

That is exactly what happened in #18: base `https://gen.pollinations.ai`, a full model list on screen, and `HTTP 404: {"success":false,...,"code":"NOT_FOUND"}` on each message.

## The change

- On a 404 — and only a 404 — `_http_request` retries once against `<base>/v1`. If it answers, that base is adopted for the rest of the process, so no later turn pays for the empty knock.
- A non-404 status on the retry (rejected key, exhausted quota) also proves the endpoint exists: the corrected base is adopted and the real error is surfaced.
- Bases that already end in a version segment (`/v1`, `/v3`) are never retried — there a second attempt has nothing to correct, and some gateways legitimately serve completions from the root (DeepSeek is configured that way in this repo).
- When both attempts 404, the error names both URLs and says the base URL looks wrong, instead of echoing the provider's body alone.
- Saved settings are not rewritten. The correction lives in the process and is announced in the log (`API base URL auto-corrected for this run: X -> Y`), so it shows up in the logs users attach to issues.

## Verification

- `pytest -q`: 8814 passed, 5 skipped.
- 12 new tests in `tests/providers/test_base_url_version_fallback.py` cover the retry, the memoized correction, both-404, the versioned-base no-op, non-404 statuses, and the streaming path.
- Live check against the real endpoint starting from the bare base: 404, retry on `/v1`, genuine answer from the versioned path.
- `ruff check jenny/ tests/` clean; pyright unchanged (the one pre-existing error on the file is untouched).

No security boundary is affected: the retry stays on the same host and scheme as the configured base, and only appends a path segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)