### PR TITLE
Give a wiki a way back to its project's chat

### DIFF
--- a/jenny/templates/ui/assets/i18n/en.json
+++ b/jenny/templates/ui/assets/i18n/en.json
@@ -639,6 +639,7 @@
     "files": "Files",
     "graph": "Graph",
     "pages": "Pages",
+    "openProjectChat": "Project chat",
     "showHiddenApps": "Show hidden apps"
   },
   "jenny": {

--- a/jenny/templates/ui/assets/i18n/it.json
+++ b/jenny/templates/ui/assets/i18n/it.json
@@ -639,6 +639,7 @@
     "files": "Files",
     "graph": "Grafo",
     "pages": "Pagine",
+    "openProjectChat": "Chat del progetto",
     "showHiddenApps": "Mostra app nascoste"
   },
   "jenny": {

--- a/jenny/templates/ui/assets/mobile-graph.js
+++ b/jenny/templates/ui/assets/mobile-graph.js
@@ -3,6 +3,7 @@ import { escapeHtml, hashString } from './shared/utils.js';
 import { i18n } from './shared/i18n.js';
 import { WikiSearchIndex } from './shared/wiki-search.js';
 import { AppState } from './shared/state.js';
+import { isOpenableProjectName } from './shared/scope-chip.js';
 
 export class GraphController {
   constructor() {
@@ -194,6 +195,11 @@ export class GraphController {
     const token = ++this._loadToken;
     const gen = this._gen;
     this.currentWiki = wiki;
+    // Accanto all'assegnazione, e non dopo la fetch: il tasto nomina la wiki
+    // che questa vista sta mostrando, e un caricamento fallito la mostra
+    // comunque (il titolo resta, il grafo diventa una riga d'errore). Ultimo
+    // chiamante vince, come per `currentWiki`.
+    this._syncProjectAction(wiki);
     this._cleanup();
     this.showLoading();
 
@@ -228,6 +234,20 @@ export class GraphController {
       // Chi è stato superato non spegne lo spinner di chi lo ha superato.
       if (!this._stale(token, gen)) this.hideLoading();
     }
+  }
+
+  /** Accende il tasto «chat del progetto» se questa vista ne ha uno da aprire.
+   *
+   *  Sul grafo home (`wiki` null) non c'è: i nodi sono *le* wiki, e non ce n'è
+   *  una da aprire più delle altre. Su una cartella con un nome che il server
+   *  non accetta come progetto non c'è nemmeno: aprirla porterebbe in
+   *  un'**altra** conversazione (v. `isOpenableProjectName`).
+   */
+  _syncProjectAction(wiki) {
+    const header = window.mobileApp?.header;
+    if (!header) return;
+    if (wiki && isOpenableProjectName(wiki)) header.showAction('open-project-chat', 'graph');
+    else header.hideAction('open-project-chat', 'graph');
   }
 
   _updateTitle(wiki) {

--- a/jenny/templates/ui/assets/mobile-header.js
+++ b/jenny/templates/ui/assets/mobile-header.js
@@ -7,6 +7,36 @@
  */
 
 import { i18n } from './shared/i18n.js';
+import { isOpenableProjectName, scopeChip } from './shared/scope-chip.js';
+
+/** Il tasto che dalla wiki porta nella chat del progetto che la possiede.
+ *
+ *  Il collegamento esisteva in una direzione sola: scegliere un progetto nello
+ *  scope chip aggancia le viste wiki e grafo a quella wiki
+ *  (`AppState.pinnedWiki`), ma dalla wiki non si tornava alla sua conversazione
+ *  se non passando dalla chat e riaprendo la tendina. La destinazione è già a
+ *  schermo — un progetto **è** una wiki, e il nome della cartella è il nome
+ *  della sessione (`project:<nome>`) — quindi non c'è niente da chiedere a
+ *  nessuno.
+ *
+ *  Nasce spento: lo accende chi sa quale wiki è a schermo
+ *  (`_syncProjectAction`, nei due controller). La Home non ne ha uno da aprire
+ *  — il grafo di tutte le wiki e l'indice delle wiki *sono* l'elenco dei
+ *  progetti, e nessuno di quelli è più aperto degli altri — e una cartella con
+ *  un nome che il server non accetta non ne ha uno raggiungibile.
+ *
+ *  Una funzione e non una costante perché i due elenchi ne prendono uno per
+ *  uno: `renderActions` oggi non scrive nelle voci che legge, ma un flag posato
+ *  su un literal condiviso comparirebbe anche nell'altra vista.
+ */
+function projectChatAction() {
+  return {
+    icon: 'ti-message-2',
+    title: i18n.t('header.openProjectChat'),
+    action: 'open-project-chat',
+    hidden: true,
+  };
+}
 
 export class ViewTitleController {
   constructor() {
@@ -34,14 +64,16 @@ export class ViewTitleController {
           { icon: 'ti-clipboard-list', title: i18n.t('header.audits'), drawer: 'audit' },
           { icon: 'ti-folder', title: i18n.t('header.files'), drawer: 'files' },
           { type: 'sep' },
-          { icon: 'ti-topology-star', title: i18n.t('header.graph'), action: 'graph' }
+          { icon: 'ti-topology-star', title: i18n.t('header.graph'), action: 'graph' },
+          projectChatAction()
         ]
       },
       graph: {
         title: i18n.t('nav.wiki'),
         actions: [
           { icon: 'ti-file-text', title: i18n.t('header.pages'), action: 'open-pages' },
-          { icon: 'ti-refresh', title: i18n.t('header.refresh'), action: 'refresh' }
+          { icon: 'ti-refresh', title: i18n.t('header.refresh'), action: 'refresh' },
+          projectChatAction()
         ]
       },
       settings: {
@@ -107,12 +139,27 @@ export class ViewTitleController {
     if (this.titleEl) this.titleEl.textContent = title;
   }
 
-  showAction(actionName) {
+  /** Accende un'azione, ma solo se chi la accende possiede ancora la modalità
+   *  corrente — la stessa guardia di :meth:`setTitle`, e per lo stesso motivo.
+   *
+   *  `actionsEl` punta al mount della modalità **a schermo**: un caricamento
+   *  lento della sezione che si sta lasciando riprende dopo il cambio e cerca il
+   *  proprio bottone nell'header di destinazione. Oggi non lo trova (i nomi
+   *  delle azioni non si ripetono fra le viste) e la riga è un no-op silenzioso,
+   *  che è il tipo di innocuo che smette di esserlo appena due viste chiamano
+   *  un'azione allo stesso modo.
+   *
+   *  `ownerMode` è opzionale per i chiamanti sincroni, che non possono sbagliare
+   *  vista: chi accende un'azione dopo un `await` lo passa.
+   */
+  showAction(actionName, ownerMode = null) {
+    if (ownerMode && ownerMode !== this.currentMode) return;
     const btn = this.actionsEl?.querySelector(`[data-action="${actionName}"]`);
     if (btn) btn.style.display = '';
   }
 
-  hideAction(actionName) {
+  hideAction(actionName, ownerMode = null) {
+    if (ownerMode && ownerMode !== this.currentMode) return;
     const btn = this.actionsEl?.querySelector(`[data-action="${actionName}"]`);
     if (btn) btn.style.display = 'none';
   }
@@ -206,6 +253,54 @@ export class ViewTitleController {
         app.switchMode('wiki', false);
         app.controllers.wiki.loadHome(true);
       }
+      return;
+    }
+    if (action === 'open-project-chat') {
+      /* La wiki a schermo la sa la vista che è a schermo, e le due la tengono
+         in un campo con lo stesso nome. Si legge da lì e non da `pinnedWiki`:
+         dentro un progetto le due risposte coincidono, ma il tasto serve
+         soprattutto **fuori**, dalla personale, dove il pin è null ed è
+         l'unica strada per entrare.
+
+         Il nome viene ricontrollato qui e non solo quando il tasto si accende:
+         fra l'accensione e la pressione la vista può essere cambiata sotto
+         (cambio progetto, link a un'altra wiki), e questo è l'ultimo punto
+         prima di cambiare conversazione — che è il solo guasto irrecuperabile
+         del disegno delle sessioni-progetto. */
+      const wiki = app.currentMode === 'graph'
+        ? app.controllers.graph?.currentWiki
+        : app.controllers.wiki?.currentWiki;
+      if (!wiki || !isOpenableProjectName(wiki)) return;
+      /* Prima la vista, poi lo scope, e l'ordine conta. `select` pubblica
+         l'aggancio, e le due viste si riagganciano solo se sono **quella a
+         schermo**: farlo da dentro la sezione wiki significa un grafo
+         ricaricato per essere buttato un istante dopo, o — peggio — la pagina
+         che si stava leggendo sostituita dall'indice del progetto un attimo
+         prima di lasciarla. Da 'chat' i due ascoltatori si limitano a segnarsi
+         il cambio e ricalcolano al rientro. */
+      app.switchMode('chat');
+      // Il primo avvio dirotta ogni navigazione sull'onboarding: se non ci
+      // siamo arrivati lo scope non si tocca. Stessa verifica di `openChat`.
+      if (app.currentMode !== 'chat') return;
+      /* E si aspetta che la chat sia pronta. `scopeChip.onSwitch` lo installa
+         lei dopo `sessionManager.init()`, che è asincrono, e alla **prima**
+         apertura della chat il controller nasce proprio in questo `switchMode`:
+         un `select()` sincrono qui cambierebbe l'etichetta del chip e nient'
+         altro — nessuno starebbe ascoltando — e il caricamento della
+         conversazione personale, arrivando dopo, rimetterebbe il chip com'era
+         con la sua `syncFromSession`. Cioè il tasto portava in chat, ma nella
+         chat sbagliata. Dalla seconda volta in poi `ready` è già risolta e
+         questo è un microtask.
+
+         `select` fa tutto il seguito — chip, placeholder, aggancio delle viste
+         e cambio di conversazione — e non fa niente se quello è già lo scope
+         aperto: da dentro il progetto questo tasto è solo la via più corta
+         verso la chat. Il thread non si legge due volte: `loadInitialHistory`
+         chiude il proprio latch da sé, e la generazione di `switchTo` scavalca
+         il caricamento della conversazione di prima. */
+      Promise.resolve(app.controllers.chat?.ready).then(() => {
+        scopeChip.select({ kind: 'project', name: wiki });
+      });
       return;
     }
     const controller = app.controllers[app.currentMode];

--- a/jenny/templates/ui/assets/mobile-wiki.js
+++ b/jenny/templates/ui/assets/mobile-wiki.js
@@ -7,6 +7,7 @@ import { AppState } from './shared/state.js';
 import { renderTree, wireTreeFolder, wireTreeFiles } from './shared/tree-renderer.js';
 import { i18n } from './shared/i18n.js';
 import { confirmDialog, promptDialog } from './shared/dialog.js';
+import { isOpenableProjectName } from './shared/scope-chip.js';
 
 export class WikiController {
   constructor() {
@@ -139,6 +140,11 @@ export class WikiController {
 
   activate() {
     this._loadInitialView();
+    // `setMode` ha appena ridisegnato le azioni, e il tasto rinasce spento a
+    // ogni rientro. Riaccenderlo non è compito del caricamento: quando la vista
+    // era già disegnata `_loadInitialView` non ne fa nessuno, e il tasto
+    // resterebbe spento sopra una pagina che il suo progetto ce l'ha.
+    this._syncProjectAction();
     if (this._localeDirty) {
       this._localeDirty = false;
       this._rerenderForLocale();
@@ -217,6 +223,7 @@ export class WikiController {
     this.isHome = true;
     this.currentWiki = null;
     this.currentPath = '_index.md';
+    this._syncProjectAction();
     AppState.wiki.currentWiki = null;
     AppState.wiki.currentPath = '_index.md';
     this.contentEl.innerHTML = `<p class="wiki-blockq">${i18n.t('wiki.loading')}</p>`;
@@ -290,6 +297,10 @@ export class WikiController {
     this.isHome = false;
     this.currentWiki = wiki;
     this.currentPath = page;
+    // Accanto all'assegnazione, e non dopo la fetch: il tasto nomina la wiki
+    // che questa vista sta mostrando, e una pagina che non si carica la mostra
+    // comunque (resta il progetto, cambia la pagina).
+    this._syncProjectAction();
     AppState.wiki.currentWiki = wiki;
     AppState.wiki.currentPath = page;
     this.contentEl.innerHTML = `<p class="wiki-blockq">${i18n.t('wiki.loading')}</p>`;
@@ -322,6 +333,21 @@ export class WikiController {
       this._settled = true;  // anche una pagina d'errore è una vista disegnata
       this.contentEl.innerHTML = `<p class="wiki-blockq" style="color: var(--error)">${i18n.t('common.error')}: ${escapeHtml(err.message)}</p>`;
     }
+  }
+
+  /** Accende il tasto «chat del progetto» se questa vista ne ha uno da aprire.
+   *
+   *  Sulla Home (`isHome`) non c'è: quell'indice *è* l'elenco delle wiki, e non
+   *  ce n'è una da aprire più delle altre. Su una cartella con un nome che il
+   *  server non accetta come progetto non c'è nemmeno: aprirla porterebbe in
+   *  un'**altra** conversazione (v. `isOpenableProjectName`).
+   */
+  _syncProjectAction() {
+    const header = window.mobileApp?.header;
+    if (!header) return;
+    const wiki = this.isHome ? null : this.currentWiki;
+    if (wiki && isOpenableProjectName(wiki)) header.showAction('open-project-chat', 'wiki');
+    else header.hideAction('open-project-chat', 'wiki');
   }
 
   _renderBreadcrumbs() {

--- a/jenny/templates/ui/assets/shared/scope-chip.js
+++ b/jenny/templates/ui/assets/shared/scope-chip.js
@@ -49,6 +49,23 @@ const DEFAULT_DIR = 'wikis';
  */
 const VALID_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
+/** True se *name* è una cartella che il server aprirebbe come conversazione.
+ *
+ *  Le due metà di `is_valid_project_name`: la forma, e il `..` che la forma non
+ *  vede (`a..b` passa la regex). Separate là e separate qui, così le due domande
+ *  restano confrontabili a occhio.
+ *
+ *  Esportata perché la stessa domanda se la pone anche chi non sta creando
+ *  niente: il tasto che dalla wiki porta nella chat del progetto esiste solo se
+ *  quel nome è un nome che il server aprirebbe. È la stessa divisione che fa
+ *  `wiki_routes.py::_collect_projects` fra `projects` e `unopenable`, e un tasto
+ *  offerto su una cartella del secondo gruppo aprirebbe **un'altra**
+ *  conversazione — il guasto per cui quella divisione esiste.
+ */
+export function isOpenableProjectName(name) {
+  return typeof name === 'string' && VALID_NAME.test(name) && !name.includes('..');
+}
+
 /** Il rifiuto del server, detto nella lingua dell'utente.
  *
  *  `err.message` viene da un `CommandError` e **è in inglese**: interpolato in
@@ -650,10 +667,10 @@ export class ScopeChip {
     });
     if (!name) return;
     const clean = name.trim();
-    // Le due metà di `is_valid_project_name`: la forma, e il `..` che la forma
-    // non vede (`a..b` passa la regex). Separate là e separate qui, così le due
-    // domande restano confrontabili a occhio.
-    if (!VALID_NAME.test(clean) || clean.includes('..')) {
+    // La stessa domanda del tasto che dalla wiki porta nella chat: una regola
+    // sola, o le due strade per lo stesso nome smetterebbero di rispondere
+    // uguale (v. `isOpenableProjectName`).
+    if (!isOpenableProjectName(clean)) {
       showToast(i18n.t('scope.invalidName'), 'error');
       return;
     }

--- a/tests/webui/test_graph_search_contract.py
+++ b/tests/webui/test_graph_search_contract.py
@@ -105,8 +105,15 @@ for (const k of ['document', 'window', 'requestAnimationFrame', 'cancelAnimation
 define('performance', { now: () => Date.now() });
 
 define('__GRAPH__', JSON.parse(fs.readFileSync(new URL('./graph.json', import.meta.url), 'utf-8')));
+// L'header sta per quello vero, e `loadGraph` ne usa tre metodi: il titolo e i
+// due che accendono e spengono il tasto verso la chat del progetto. Un finto a
+// cui manca un metodo del vero non e' un finto piu' piccolo, e' un errore in
+// mezzo alla prova: `showAction is not a function` faceva morire l'import prima
+// del primo assert sulla maschera di ricerca.
 window.mobileApp = {
-  currentMode: 'graph', header: { setTitle() {} }, pushNav() {},
+  currentMode: 'graph',
+  header: { setTitle() {}, showAction() {}, hideAction() {} },
+  pushNav() {},
   takePendingGraph: () => null, switchMode() {}, controllers: {},
 };
 define('mobileApp', window.mobileApp);

--- a/tests/webui/test_scope_pin_and_create_client.py
+++ b/tests/webui/test_scope_pin_and_create_client.py
@@ -93,6 +93,18 @@ def _const_block(source: str, name: str) -> str:
     return m.group(0)
 
 
+def _function(source: str, name: str) -> str:
+    """Una funzione di modulo, presa dal sorgente. `export` cade: qui non serve.
+
+    Stessa ragione di :func:`_const`: `isOpenableProjectName` è la regola che
+    decide quali nomi arrivano al server, e una copia a mano nel test
+    smetterebbe di misurare quella vera al primo cambio.
+    """
+    m = re.search(rf"(?ms)^export function {re.escape(name)}\(.*?^\}}$", source)
+    assert m, f"funzione {name} non trovata"
+    return m.group(0).removeprefix("export ")
+
+
 _HARNESS = """
 import assert from 'node:assert/strict';
 
@@ -191,7 +203,10 @@ function serverError(code, message) {
 def _harness() -> str:
     src = _read(CHIP_JS)
     return (
-        _HARNESS.replace("__VALID_NAME__", _const(src, "VALID_NAME"))
+        _HARNESS.replace(
+            "__VALID_NAME__",
+            _const(src, "VALID_NAME") + "\n" + _function(src, "isOpenableProjectName"),
+        )
         .replace("__CREATE_ERROR_KEYS__", _const_block(src, "CREATE_ERROR_KEYS"))
         .replace("__PUBLISH_PIN__", _member(src, "_publishPin"))
         .replace("__SYNC_FROM_SESSION__", _member(src, "syncFromSession"))

--- a/tests/webui/test_wiki_to_project_button_client.py
+++ b/tests/webui/test_wiki_to_project_button_client.py
@@ -1,0 +1,400 @@
+"""Dalla wiki alla chat del suo progetto: il tasto, e le due condizioni che lo spengono.
+
+Il collegamento fra un progetto e la sua wiki esisteva **in una direzione sola**:
+lo scope chip pubblica `AppState.pinnedWiki` e le viste wiki e grafo si
+agganciano a quella wiki (`test_project_views_contract`), ma dalla wiki non si
+tornava alla conversazione se non passando dalla chat e riaprendo la tendina. La
+destinazione è già a schermo — un progetto *è* una wiki, e il nome della cartella
+è il nome della sessione — quindi il tasto non deve chiedere niente a nessuno.
+
+Le due condizioni che lo spengono sono il punto di questi test:
+
+**La Home non ha un progetto da aprire.** Il grafo di tutte le wiki e l'indice
+delle wiki *sono* l'elenco dei progetti: nessuno di quelli è più aperto degli
+altri, e un tasto acceso lì dovrebbe sceglierne uno per conto dell'utente.
+
+**Una cartella che il server non aprirebbe non si offre.** ``wiki_routes.py::
+_collect_projects`` divide le wiki in ``projects`` e ``unopenable`` proprio
+perché un nome che il server elenca dev'essere un nome che il server accetta —
+altrimenti si tappa «Ricerca ETF» e si finisce in un'**altra** conversazione. Il
+tasto fa la stessa domanda con la stessa regola (`isOpenableProjectName`, la
+sola espressione della regola nel client), e la rifà al momento della pressione:
+fra l'accensione e il tocco la vista può essere cambiata sotto, e cambiare
+conversazione è il solo guasto irrecuperabile del disegno delle sessioni-progetto.
+
+E un ordine: **prima la vista, poi lo scope.** `select` pubblica l'aggancio, e i
+due ascoltatori si riagganciano solo se sono la vista a schermo — dalla sezione
+wiki significherebbe un grafo ricaricato per essere buttato un istante dopo, o
+la pagina che si sta leggendo sostituita dall'indice del progetto un attimo prima
+di lasciarla.
+
+I metodi si estraggono dal sorgente e si eseguono in node, come in
+``test_scope_pin_and_create_client.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ASSETS = Path(__file__).resolve().parents[2] / "jenny" / "templates" / "ui" / "assets"
+HEADER_JS = ASSETS / "mobile-header.js"
+GRAPH_JS = ASSETS / "mobile-graph.js"
+WIKI_JS = ASSETS / "mobile-wiki.js"
+CHIP_JS = ASSETS / "shared" / "scope-chip.js"
+I18N = ASSETS / "i18n"
+
+_NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(_NODE is None, reason="node non disponibile")
+
+
+def _src(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _member(path: Path, name: str) -> str:
+    """Il corpo di un metodo di classe, indentato di due spazi."""
+    m = re.search(
+        rf"\n  ((?:async |get |static )?{re.escape(name)}\([^)]*\)\s*\{{.*?)\n  \}}",
+        _src(path),
+        re.S,
+    )
+    assert m, f"{name} non trovato in {path.name}"
+    return m.group(1) + "\n  }"
+
+
+def _const(path: Path, name: str) -> str:
+    """La riga di una costante di modulo, presa dal sorgente e non riscritta."""
+    m = re.search(rf"(?m)^const {re.escape(name)} = .*;$", _src(path))
+    assert m, f"const {name} non trovata in {path.name}"
+    return m.group(0)
+
+
+def _function(path: Path, name: str) -> str:
+    """Una funzione di modulo, presa dal sorgente. `export` cade: qui non serve."""
+    m = re.search(rf"(?ms)^export function {re.escape(name)}\(.*?^\}}$", _src(path))
+    assert m, f"funzione {name} non trovata in {path.name}"
+    return m.group(0).removeprefix("export ")
+
+
+def _run_js(harness: str, script: str) -> None:
+    proc = subprocess.run(
+        [str(_NODE), "--input-type=module", "-e", harness + "\n" + script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+# ── La pressione ──────────────────────────────────────────────────────────
+
+_PRESS_HARNESS = """
+import assert from 'node:assert/strict';
+
+__IS_OPENABLE__
+
+// Il registro condiviso: le due mosse del tasto devono avvenire *in quest'ordine*.
+let log = [];
+
+const scopeChip = {
+  select(scope) { log.push(['select', scope.kind, scope.name]); },
+};
+
+/** L'app attorno al tasto.
+ *
+ *  `chatReady` è la promessa che la chat espone: `sessionManager.init()`, cioè
+ *  anche l'installazione di `scopeChip.onSwitch`. `blocked` è il primo avvio,
+ *  che dirotta ogni navigazione sull'onboarding.
+ */
+function makeApp(mode, { graphWiki = null, wikiWiki = null, chatReady = null, blocked = false } = {}) {
+  const app = {
+    currentMode: mode,
+    controllers: {
+      graph: { currentWiki: graphWiki },
+      wiki: { currentWiki: wikiWiki },
+      chat: { ready: chatReady === null ? Promise.resolve() : chatReady },
+    },
+    switchMode(next) {
+      log.push(['switchMode', next]);
+      app.currentMode = blocked ? 'onboarding' : next;
+    },
+  };
+  global.window = { mobileApp: app };
+  log = [];
+  return app;
+}
+
+/** Lascia girare i microtask in coda: `select` arriva dopo `chat.ready`. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+class Header {
+__HANDLE_ACTION__
+}
+const header = new Header();
+"""
+
+
+def _press_harness() -> str:
+    return (
+        _PRESS_HARNESS.replace("__IS_OPENABLE__", _const(CHIP_JS, "VALID_NAME") + "\n" + _function(CHIP_JS, "isOpenableProjectName"))
+        .replace("__HANDLE_ACTION__", _member(HEADER_JS, "handleAction"))
+    )
+
+
+def test_the_button_opens_the_wiki_on_screen_from_both_views() -> None:
+    """La wiki la sa la vista a schermo, e le due la tengono nello stesso campo."""
+    _run_js(
+        _press_harness(),
+        """
+        // Dal grafo. Il controller della wiki porta un'altra wiki apposta: se il
+        // tasto leggesse quello, aprirebbe la conversazione sbagliata.
+        makeApp('graph', { graphWiki: 'patreon', wikiWiki: 'salute' });
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.deepEqual(log, [['switchMode', 'chat'], ['select', 'project', 'patreon']]);
+
+        // Dalla pagina wiki, e stavolta è il grafo a portare il residuo.
+        makeApp('wiki', { graphWiki: 'patreon', wikiWiki: 'salute' });
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.deepEqual(log, [['switchMode', 'chat'], ['select', 'project', 'salute']]);
+        """,
+    )
+
+
+def test_the_view_moves_before_the_scope() -> None:
+    """Invertire l'ordine ricarica (o riscrive) la vista che si sta lasciando.
+
+    `select` pubblica l'aggancio, e i due ascoltatori di `pinnedWiki` si
+    riagganciano **solo se sono la vista a schermo**: pubblicarlo da dentro la
+    sezione wiki significa un `loadGraph` intero buttato via un istante dopo, o
+    la pagina che si sta leggendo sostituita dall'indice del progetto un attimo
+    prima di lasciarla — e con lei `lastWikiPage`, che è dove si torna.
+    """
+    _run_js(
+        _press_harness(),
+        """
+        makeApp('graph', { graphWiki: 'patreon' });
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.equal(log[0][0], 'switchMode', 'lo scope è cambiato mentre la wiki era ancora a schermo');
+        """,
+    )
+
+
+def test_the_scope_waits_for_the_chat_to_be_ready() -> None:
+    """Alla prima apertura la chat *nasce* in questo `switchMode`.
+
+    `scopeChip.onSwitch` lo installa il controller della chat dopo
+    `sessionManager.init()`, che è asincrono: un `select()` sincrono cambierebbe
+    l'etichetta del chip e nient'altro — non c'è ancora nessuno che ascolti — e
+    il caricamento della conversazione personale, arrivando dopo, rimetterebbe
+    il chip com'era con la propria `syncFromSession`. Il tasto portava in chat,
+    ma nella chat sbagliata: visto sul telefono il 01/09, prima apertura dopo un
+    riavvio dell'app.
+    """
+    _run_js(
+        _press_harness(),
+        """
+        let ready;
+        const pending = new Promise((resolve) => { ready = resolve; });
+        makeApp('graph', { graphWiki: 'patreon', chatReady: pending });
+
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.deepEqual(log, [['switchMode', 'chat']],
+                         'lo scope è cambiato prima che la chat potesse ascoltarlo');
+
+        ready();
+        await settle();
+        assert.deepEqual(log, [['switchMode', 'chat'], ['select', 'project', 'patreon']]);
+        """,
+    )
+
+
+def test_a_navigation_that_did_not_land_leaves_the_scope_alone() -> None:
+    """Il primo avvio dirotta ogni navigazione sull'onboarding.
+
+    Cambiare scope lì significherebbe una conversazione-progetto aperta sotto
+    una schermata di setup, e il chip che nomina un progetto appena l'utente ne
+    esce. Stessa verifica di `openChat`, che per questo ritorna un booleano.
+    """
+    _run_js(
+        _press_harness(),
+        """
+        makeApp('graph', { graphWiki: 'patreon', blocked: true });
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.deepEqual(log, [['switchMode', 'chat']]);
+        """,
+    )
+
+
+def test_nothing_happens_without_a_wiki_or_on_a_name_the_server_refuses() -> None:
+    """La Home non ha un progetto da aprire, e «Ricerca ETF» ne aprirebbe un altro.
+
+    Il controllo è **qui** e non solo dove il tasto si accende: fra l'accensione
+    e la pressione la vista può essere cambiata sotto (un cambio progetto, un
+    link a un'altra wiki), e questo è l'ultimo punto prima di cambiare
+    conversazione.
+    """
+    _run_js(
+        _press_harness(),
+        """
+        // Grafo home: i nodi sono le wiki, non c'è una wiki corrente.
+        makeApp('graph', { graphWiki: null });
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.deepEqual(log, [], 'la Home ha scelto un progetto per conto dell\\'utente');
+
+        // Indice delle wiki: stessa cosa dal lato pagina.
+        makeApp('wiki', { wikiWiki: null });
+        header.handleAction('open-project-chat');
+        await settle();
+        assert.deepEqual(log, []);
+
+        // I nomi che `_collect_projects` mette in `unopenable`, e i due che la
+        // regex non vede da sé.
+        for (const name of ['Ricerca ETF', '.nascosta', 'a..b', 'x'.repeat(65)]) {
+          makeApp('wiki', { wikiWiki: name });
+          header.handleAction('open-project-chat');
+          await settle();
+          assert.deepEqual(log, [], 'aperto ' + JSON.stringify(name));
+        }
+        """,
+    )
+
+
+# ── L'accensione ──────────────────────────────────────────────────────────
+
+_SYNC_HARNESS = """
+import assert from 'node:assert/strict';
+
+__IS_OPENABLE__
+
+class Header {
+  constructor(mode) {
+    this.currentMode = mode;
+    // Il bottone nasce spento: `renderActions` lo disegna con `display:none`.
+    this.btn = { style: { display: 'none' } };
+    this.actionsEl = {
+      querySelector: (sel) => (sel.includes('open-project-chat') ? this.btn : null),
+    };
+  }
+__SHOW_ACTION__
+__HIDE_ACTION__
+}
+
+class Graph {
+  constructor(wiki) { this.currentWiki = wiki; }
+__GRAPH_SYNC__
+}
+
+class Wiki {
+  constructor(wiki, isHome = false) { this.currentWiki = wiki; this.isHome = isHome; }
+__WIKI_SYNC__
+}
+
+/** Monta un header nella modalità *mode* e ritorna il display del tasto dopo
+ *  che la vista ha detto la sua. */
+function afterSync(mode, view, arg) {
+  const header = new Header(mode);
+  global.window = { mobileApp: { header } };
+  view._syncProjectAction(arg);
+  return header.btn.style.display;
+}
+"""
+
+
+def _sync_harness() -> str:
+    return (
+        _SYNC_HARNESS.replace("__IS_OPENABLE__", _const(CHIP_JS, "VALID_NAME") + "\n" + _function(CHIP_JS, "isOpenableProjectName"))
+        .replace("__SHOW_ACTION__", _member(HEADER_JS, "showAction"))
+        .replace("__HIDE_ACTION__", _member(HEADER_JS, "hideAction"))
+        .replace("__GRAPH_SYNC__", _member(GRAPH_JS, "_syncProjectAction"))
+        .replace("__WIKI_SYNC__", _member(WIKI_JS, "_syncProjectAction"))
+    )
+
+
+def test_the_button_lights_up_only_where_there_is_a_project_to_open() -> None:
+    """Le stesse due condizioni, dal lato dell'accensione."""
+    _run_js(
+        _sync_harness(),
+        """
+        // Grafo di una wiki apribile.
+        assert.equal(afterSync('graph', new Graph('patreon'), 'patreon'), '');
+        // Grafo home: nessuna wiki.
+        assert.equal(afterSync('graph', new Graph(null), null), 'none');
+        // Cartella che il server non aprirebbe.
+        assert.equal(afterSync('graph', new Graph('Ricerca ETF'), 'Ricerca ETF'), 'none');
+
+        // Pagina di una wiki apribile.
+        assert.equal(afterSync('wiki', new Wiki('salute')), '');
+        // Indice delle wiki: `isHome` vince sul residuo di `currentWiki`, che è
+        // quel che `activate()` incontra rientrando su una Home già disegnata.
+        assert.equal(afterSync('wiki', new Wiki('salute', true)), 'none');
+        assert.equal(afterSync('wiki', new Wiki(null)), 'none');
+        assert.equal(afterSync('wiki', new Wiki('Ricerca ETF')), 'none');
+        """,
+    )
+
+
+def test_a_late_load_does_not_light_up_another_view_header() -> None:
+    """`actionsEl` è il mount della vista **a schermo**, non di chi lo chiama.
+
+    Un caricamento lento della sezione che si sta lasciando riprende dopo il
+    cambio: senza `ownerMode` accenderebbe (o spegnerebbe) un bottone
+    nell'header di destinazione. È la stessa guardia di `setTitle`, che esiste
+    per lo stesso motivo.
+    """
+    _run_js(
+        _sync_harness(),
+        """
+        // Il grafo finisce di caricare quando a schermo c'è già il workspace.
+        assert.equal(afterSync('workspace', new Graph('patreon'), 'patreon'), 'none',
+                     'il grafo ha acceso un tasto nell\\'header di un\\'altra vista');
+        // E il verso opposto: chi spegne non deve spegnere in casa d'altri.
+        const header = new Header('workspace');
+        header.btn.style.display = '';
+        global.window = { mobileApp: { header } };
+        new Wiki(null)._syncProjectAction();
+        assert.equal(header.btn.style.display, '');
+        """,
+    )
+
+
+# ── Il contorno: il tasto nasce spento, e parla due lingue ────────────────
+
+
+def test_the_button_is_born_off_in_both_views() -> None:
+    """Acceso di default comparirebbe sulla Home, dove non porta da nessuna parte.
+
+    Il momento è quello: `setMode` ridisegna le azioni a ogni cambio vista, e
+    fra quel disegno e il primo `_syncProjectAction` c'è un fotogramma.
+    """
+    src = _src(HEADER_JS)
+    factory = re.search(r"(?ms)^function projectChatAction\(\) \{.*?^\}$", src)
+    assert factory, "projectChatAction non trovata"
+    assert "hidden: true" in factory.group(0), "il tasto nasce acceso"
+    assert "action: 'open-project-chat'" in factory.group(0)
+
+    for mode in ("wiki", "graph"):
+        block = re.search(rf"(?ms)^      {mode}: \{{.*?^      \}},$", src)
+        assert block, f"la configurazione di {mode} non è dove ci si aspetta"
+        assert "projectChatAction()" in block.group(0), (
+            f"la vista {mode} non offre la strada verso la chat del progetto"
+        )
+
+
+def test_the_button_label_exists_in_both_locales() -> None:
+    """Una chiave a metà stampa `header.openProjectChat` sul bottone."""
+    for locale in ("it", "en"):
+        strings = json.loads((I18N / f"{locale}.json").read_text(encoding="utf-8"))
+        label = strings.get("header", {}).get("openProjectChat")
+        assert label, f"header.openProjectChat manca in {locale}.json"


### PR DESCRIPTION
## What

A button in the header of both Wiki views (graph and pages) that opens the chat of the project that owns the wiki on screen. One tap: it switches scope and view, and Back returns where you were.

The link between a project and its wiki ran **one way only**. Picking a project in the scope chip publishes `AppState.pinnedWiki` and both views follow it (`test_project_views_contract`), but from a wiki there was no way back to the conversation except returning to the chat and reopening the dropdown. The destination is already on screen — a project *is* a wiki, and the folder name is the session name (`project:<name>`) — so the button has nothing to ask anyone.

## The two cases where it is off

- **The Home.** The graph of all wikis and the wiki index *are* the list of projects: lighting the button there would mean picking one on the user's behalf.
- **A name the server would not accept.** `wiki_routes.py::_collect_projects` splits wikis into `projects` and `unopenable` exactly because a name the server lists must be a name the server accepts; a button offered on the second group would open **another** conversation. The rule now has a single expression in the client — `isOpenableProjectName`, exported from `scope-chip.js` and used by project creation too — and the button asks it again when pressed, because between lighting up and the tap the view can change underneath.

## Two orderings that are not incidental

- **The view moves before the scope.** `select` publishes the pin, and the two views re-anchor only when they are the one on screen: publishing from inside the Wiki section means a graph reloaded to be thrown away an instant later, or the page being read replaced by the project's index just before leaving it.
- **The scope waits for the chat to be ready.** `scopeChip.onSwitch` is installed by the chat controller after `sessionManager.init()`, which is async, and on the *first* open that controller is born in this very `switchMode`. A synchronous `select()` changed the chip label and nothing else — nobody was listening yet — and the personal history load then put the chip back with its own `syncFromSession`: the button led to the chat, but the wrong one. Found on the device, not in review.

`showAction`/`hideAction` gain the same optional `ownerMode` guard `setTitle` already has, for the same reason: `actionsEl` points at the mount of the mode on screen.

## Tests

Nine new client tests in `tests/webui/test_wiki_to_project_button_client.py` — methods extracted from source and run in node, like the other `*_client.py` tests. Mutation-checked: inverting the order, dropping the name check, dropping the `ownerMode` guard, dropping the wait on `ready` and dropping the `isHome` gate each fail the intended test. `test_scope_pin_and_create_client.py`'s harness grew the new function, since `_createProject` now calls it.

`ruff` clean, pyright 0 errors on the blocking subset, 9090 tests green.

## Device

Unihertz Titan 2, release build: absent on Wikis, present on `Graph: patreon-creator` and on a wiki page, and from a cold start in graph view the button lands in the project conversation (chip `wikis > etf-finance`, placeholder "Ask something about etf-finance...").

No security boundary is touched: the button changes a client-side scope, and the server keeps deciding which names are projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
