### PR TITLE
Stop four silent app defects, let an app show its own server, and pin the CSP

### DIFF
--- a/.agent/jenny-apps.md
+++ b/.agent/jenny-apps.md
@@ -40,7 +40,20 @@ in-workspace equivalent.
 ## Actions (the contract)
 
 Actions are declared in `app.json` with a JSON Schema for their parameters. They are
-declarative — the gateway never executes per-app code (no plugin system). Two kinds:
+declarative — the gateway never executes per-app code (no plugin system).
+
+**`actions` is optional** (since Sept 2026). An app whose only job is to draw a screen has
+nothing agent-facing to declare, and the previous non-empty requirement made that app
+impossible: the observed result was an *invented* action added purely to satisfy the schema,
+which then shipped broken. `AppToolsSyncer` registers zero tools for such an app, which is
+the correct outcome. The boundary paragraph above always said an app "can" carry an
+agent-facing side — the code disagreed with it.
+
+**Never `server.auth`.** There is no credential store; `_parse_manifest` rejects a manifest
+declaring it (app loads broken, remedy named) and `execute_http_action` refuses with 501 as
+a second line. See `.agent/security.md`.
+
+Two kinds:
 
 - `storage`: typed mutations/queries on collections under `data/` (append, set, update,
   delete, query), validated by the gateway before writing.
@@ -56,7 +69,7 @@ Example manifest:
 ```json
 {
   "name": "Piante",
-  "server": { "baseUrl": "http://192.168.1.50:8080", "auth": { "secretRef": "piante_token" } },
+  "server": { "baseUrl": "http://192.168.1.50:8080" },
   "actions": [
     { "name": "lista_piante",   "kind": "http", "method": "GET", "path": "/plants",
       "description": "Elenco piante con stato" },
@@ -67,6 +80,46 @@ Example manifest:
   ]
 }
 ```
+
+## Vista esterna (`view: {"kind": "external"}`)
+
+Un'app puo' dichiarare che il suo schermo **e' la UI del suo server**, invece di
+`app/index.html`:
+
+```json
+{ "name": "Telecomando", "description": "...",
+  "server": { "baseUrl": "http://hps:8091" },
+  "view": { "kind": "external" } }
+```
+
+`actions` e `app/index.html` diventano entrambi superflui (il validatore avvisa se
+`index.html` c'e' comunque: non verrebbe mai mostrato).
+
+**Perche' esiste.** Un iframe verso un `http://` non-loopback non parte affatto: la
+network security config dell'APK permette il cleartext solo verso il gateway, e la
+WebView risponde `ERR_CLEARTEXT_NOT_PERMITTED` prima di aprire un socket. Prima di
+Sett 2026 "mostrami il mio server" non era esprimibile, e un'app che ci provava era
+un riquadro bianco senza messaggi.
+
+**Come funziona.** `GET /api/webui/apps/<slug>/view` avvia `apps/proxy.py::AppViewProxy`
+— un listener su `127.0.0.1:<porta effimera>` che inoltra a `server.baseUrl` a livello
+di byte — e torna `{"url": ...}`. La SPA incornicia quell'URL. `.../view/close` chiude
+il listener; un idle timeout lo chiude comunque se quel segnale non arriva.
+
+Due vincoli spiegano la forma:
+
+- **Il proxy non puo' essere una route del gateway.** Il gateway gira sul parser di
+  `websockets`, che non legge il body: un POST non passerebbe, e una UI remota reale
+  ne fa. Ed e' anche il motivo per cui non e' un prefisso di path — i path assoluti
+  della pagina remota (`/style.css`) si risolverebbero sulla radice del gateway.
+- **La vista esterna non e' annidata dentro l'app-frame.** I flag di sandbox si
+  ereditano nei frame figli, quindi annidarla le darebbe un'origine opaca: cookie
+  bloccati, `localStorage` che solleva, `fetch` con `Origin: null`. Ha il suo overlay
+  con `allow-same-origin`, che li' e' sicuro perche' l'origine e' quella del proxy,
+  non quella del gateway (porta diversa). Threat model completo in `.agent/security.md`.
+
+Solo `http://`: un server `https` non ha bisogno del proxy (la policy cleartext non lo
+tocca) e il proxy lo rifiuta dicendolo.
 
 ## One contract, three consumers
 
@@ -115,10 +168,19 @@ chat DOM; it only talks to its own endpoints.
 
 ## Credentials
 
-`app.json` holds only a reference: `"auth": {"secretRef": "..."}`. The actual secret lives in
-a separate store excluded from agent reads (hook point:
-`jenny/security/workspace_access.py`) and is injected by the proxy at call time. Tokens
-never enter the LLM context or app HTML.
+**Not implemented, and `server.auth` is rejected — not tolerated.** The design was: `app.json`
+holds only a reference (`"auth": {"secretRef": "..."}`), the secret lives in a separate store
+excluded from agent reads (hook point: `jenny/security/workspace_access.py`), and the proxy
+injects it at call time. None of that store exists.
+
+Until it does, a manifest declaring `server.auth` is **rejected at load** by `_parse_manifest`
+(the app shows as broken, with the remedy in the message) and refused with 501 by
+`execute_http_action` as a second line. Before Sept 2026 only the 501 existed *and* the
+app-creator skill instructed writing `secretRef` anyway "so manifests keep working when the
+store lands" — so an app could validate clean, open, and have every http action dead. It
+happened. An app server must be reachable without credentials.
+
+Tokens still never enter the LLM context or app HTML.
 
 ## App creation
 

--- a/.agent/security.md
+++ b/.agent/security.md
@@ -113,15 +113,64 @@ nomi.
 
 ### Jenny Apps server SSRF policy (intentionally more permissive)
 
-Jenny App `http` actions use a **distinct, deliberately more permissive** policy, `validate_app_server_target` (`security/network.py`), backed by `_APP_SERVER_BLOCKED_NETWORKS`. Unlike `validate_url_target`, it **allows RFC1918 private ranges** (`10/8`, `172.16/12`, `192.168/16`) and IPv6 ULA (`fc00::/7`) **by design**: an app server is a user-declared LAN device, reachable at a `server.baseUrl` that the user sees and approves in the manifest. Loopback (`127.0.0.0/8`, `::1`), link-local / cloud metadata (`169.254.0.0/16`), `0.0.0.0/8`, and CGNAT (`100.64.0.0/10`) remain blocked — so an app manifest cannot use the proxy as an authenticated bridge to the gateway's own API. Redirects are never followed, so a server cannot bounce the proxy to a blocked address.
+Jenny App `http` actions use a **distinct, deliberately more permissive** policy, `validate_app_server_target` (`security/network.py`), backed by `_APP_SERVER_BLOCKED_NETWORKS`. Unlike `validate_url_target`, it **allows RFC1918 private ranges** (`10/8`, `172.16/12`, `192.168/16`), IPv6 ULA (`fc00::/7`) **and CGNAT (`100.64.0.0/10`)** **by design**: an app server is a user-declared LAN *or tailnet* device, reachable at a `server.baseUrl` that the user sees and approves in the manifest. Loopback (`127.0.0.0/8`, `::1`), link-local / cloud metadata (`169.254.0.0/16`) and `0.0.0.0/8` remain blocked. Redirects are never followed, so a server cannot bounce the proxy to a blocked address.
 
-As a related safeguard, `server.auth` is **fail-closed**: when an app declares it needs authentication but no credential store exists yet, the action is refused with a 501 rather than being sent unauthenticated (`apps/http.py`).
+**CGNAT was blocked until Sept 2026, and the re-evaluation the Rule below asks for is this.** The old justification — quoted verbatim — was that keeping it blocked meant "an app manifest cannot use the proxy as an authenticated bridge to the gateway's own API". That is the argument for blocking **loopback**, which still is blocked; a CGNAT address does not reach the gateway. The two had been flattened into one sentence, so the range was carrying a reason that was not about it.
 
-**Rule**: Keep the two policies separate. Widening the app-server allowlist further (or letting it follow redirects) requires re-evaluating the LAN-device threat model; do not route general agent web fetches through `validate_app_server_target`.
+Measured consequence of the old state: a Jenny App could never reach the user's own Tailscale server. The only documented escape hatch was `security.ssrfWhitelist`, which is **global** — using it to let one app talk to one server would have opened CGNAT to `web_fetch` and to every target the model picks. That is a strictly worse trade than a narrow permission in the one policy that needs it, and it is the same trade already made for SSH (see below).
+
+The criterion that actually separates the three policies on CGNAT is **who chooses the address**: an SSH host is typed by the user in Settings, a `server.baseUrl` is declared by the user in a manifest they can read, and in `web_fetch` the address is chosen by the model. The first two get CGNAT; the third does not. Fixed by `test_tailscale_allowed_where_the_user_names_the_target_never_where_the_model_does` (`tests/security/test_ssrf_extended.py`), which asserts all three with an **empty** whitelist — so a future regression to the global-whitelist shortcut fails the test.
+
+`server.auth` is **fail-closed twice over**: `_parse_manifest` (`apps/manifest.py`) rejects a manifest declaring it, so the app loads as broken with the remedy named, and `execute_http_action` (`apps/http.py`) still refuses with 501 if such a manifest reaches it by another route. Before Sept 2026 only the 501 existed, and the app-creator skill actively *instructed* writing `"auth": {"secretRef": ...}` — so an app could validate clean and ship with every http action dead. That advice is withdrawn in `skills/app-creator/SKILL.md`.
+
+**Rule**: Keep the three policies separate, and argue any widening from *who names the target*, not from how a range feels. Letting the app-server policy follow redirects, or routing general agent web fetches through `validate_app_server_target`, both still require a fresh threat-model pass.
+
+### Jenny App external-view proxy (loopback listener)
+
+An app declaring `view: {"kind": "external"}` gets its screen from its own server instead of
+`app/index.html`, served through `apps/proxy.py::AppViewProxy`: an `asyncio` listener on
+`127.0.0.1:<ephemeral>` that forwards to `server.baseUrl` at byte level. It exists because the
+APK's `network_security_config.xml` permits cleartext only to loopback, so a WebView framing a
+non-loopback `http://` gets `ERR_CLEARTEXT_NOT_PERMITTED` before a socket opens — going through
+loopback sidesteps that without widening the policy or baking a personal hostname into the APK.
+
+What bounds the surface:
+
+- **Bind is `127.0.0.1` only**, never an external interface (fixed by `test_binds_only_on_loopback`).
+- **One fixed upstream**, validated once at `start()` with `validate_app_server_target`. The proxy
+  is not steerable to another address, and `test_start_actually_consults_the_ssrf_gate` exists so
+  that stubbing the gate in the transport tests cannot hide its removal.
+- **Capability**: the first navigation must present a 128-bit secret in the path; the proxy 302s
+  and moves it into a cookie, so the remote page's root-absolute paths keep working. No cookie and
+  no prefix → 403. This is load-bearing, because `127.0.0.1:<port>` is reachable by **any** app on
+  the phone and an ephemeral port is scannable in seconds.
+  - Known wart, deliberately accepted: cookies are per-host and **ignore the port**, so the
+    browser sends it to anything on `127.0.0.1`. In practice that is this proxy and the gateway
+    (both ours) — and it is why `_rebuild_head` **strips** the cookie from the forwarded request:
+    the user's own server must not see it either.
+- **Lifetime**: closed by `.../view/close` when the UI closes the view, with an idle timeout as
+  the backstop. The listeners live in the gateway process and die with it; there is no container
+  shutdown hook.
+- Redirects are not resolved by the proxy — they are streamed to the browser, which resolves them
+  against the proxy origin, so a redirect cannot move the tunnel to another host.
+
+**The sandbox is wider here, and the reason is the origin, not trust.** A normal app is served
+from the *gateway's* origin, so `allow-same-origin` would hand it the SPA's DOM, `localStorage`
+and the gateway API with the token — hence `sandbox="allow-scripts"` and nothing else. An external
+view sits on `http://127.0.0.1:<ephemeral>`: different port → **different origin**, so
+`allow-same-origin` returns only the proxy's own origin and the same-origin policy still keeps it
+out of the SPA. Without it the page is effectively dead (opaque origin: no cookies, `localStorage`
+throws, its own fetches carry `Origin: null`). This is also why an external view gets its own
+overlay rather than being nested inside the app frame: **sandbox flags are inherited by nested
+browsing contexts**, so nesting would restore the opaque origin.
+
+**Rule**: The capability check and the loopback bind are the two things holding this up — do not
+"simplify" either. Serving an external view from the gateway's own origin, or adding
+`allow-same-origin` to the normal app frame, both defeat the isolation entirely.
 
 ### SSH target policy (a third one, wider still)
 
-`validate_ssh_target` (`security/network.py`), backed by `_SSH_BLOCKED_NETWORKS`, allows RFC1918, IPv6 ULA **and** CGNAT (`100.64.0.0/10`), blocking only `0.0.0.0/8`, loopback and link-local/metadata. CGNAT is allowed here rather than through `configure_ssrf_whitelist` on purpose: the whitelist is global, so opening it for Tailscale would also open CGNAT to `web_fetch` and to Jenny Apps — a narrow permission in one policy beats a wide one across all three. What backs the extra room is that an SSH host is user-typed in Settings and host-key pinned before any connection, not that SSH is inherently safer.
+`validate_ssh_target` (`security/network.py`), backed by `_SSH_BLOCKED_NETWORKS`, allows RFC1918, IPv6 ULA **and** CGNAT (`100.64.0.0/10`), blocking only `0.0.0.0/8`, loopback and link-local/metadata. CGNAT is allowed here rather than through `configure_ssrf_whitelist` on purpose: the whitelist is global, so opening it for Tailscale would also open CGNAT to `web_fetch`, where the model picks the address — a narrow permission in each policy that needs it beats a wide one across all three. (The Jenny Apps policy now allows CGNAT on the same grounds, on its own; it did not until Sept 2026.) What backs the extra room is that an SSH host is user-typed in Settings and host-key pinned before any connection, not that SSH is inherently safer.
 
 **Rule**: Loopback stays blocked in all three policies — it is the phone itself, and the gateway's own API lives there.
 

--- a/android/app/src/main/java/com/flagdizero/jenny/MainActivity.kt
+++ b/android/app/src/main/java/com/flagdizero/jenny/MainActivity.kt
@@ -886,12 +886,52 @@ class MainActivity : AppCompatActivity() {
                 if (isMain) {
                     mainFrameError = true
                     if (!loaded) scheduleRetry()
+                } else if (error != null) {
+                    reportSubframeError(view, request, error)
                 }
             }
         }
 
         Log.i(TAG, "Waiting for gateway on $GATEWAY_URL ...")
         wv.loadUrl(resolvedGatewayUrl)
+    }
+
+    /**
+     * Consegna alla SPA il fallimento di un sub-frame, che altrimenti non lo
+     * saprebbe mai.
+     *
+     * **Perché serve.** Un iframe che non carica non emette niente di
+     * osservabile dal JS della pagina che lo contiene: cross-origin, `onerror`
+     * non scatta e `contentDocument` è inaccessibile. Il risultato misurato è un
+     * riquadro bianco e zero informazione — per *qualunque* causa: 404, script
+     * rotto, o (il caso che ha portato qui) `ERR_CLEARTEXT_NOT_PERMITTED` su una
+     * Jenny App che incorniciava un `http://` non-loopback. L'errore esisteva
+     * solo in logcat, che l'utente non legge e l'agente non può leggere: sei
+     * occorrenze in un'ora senza che niente arrivasse a nessuno.
+     *
+     * Il canale è lo stesso già usato per `jenny-gesture-insets`
+     * (v. refreshGestureInsets): un CustomEvent sulla window della SPA. Il
+     * payload passa da [JSONObject] e non da concatenazione di stringhe —
+     * l'URL arriva dalla rete e finirebbe dentro codice JS valutato.
+     */
+    private fun reportSubframeError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError
+    ) {
+        val wv = view ?: webView ?: return
+        if (!loaded) return  // la SPA non c'è ancora: non c'è nessuno in ascolto
+        val detail = JSONObject().apply {
+            put("url", request?.url?.toString() ?: "")
+            put("host", request?.url?.host ?: "")
+            put("description", error.description?.toString() ?: "")
+            put("errorCode", error.errorCode)
+        }
+        wv.evaluateJavascript(
+            "window.dispatchEvent(new CustomEvent('jenny-subframe-error'," +
+                "{detail:$detail}))",
+            null
+        )
     }
 
     /**

--- a/jenny/apps/http.py
+++ b/jenny/apps/http.py
@@ -69,6 +69,14 @@ async def execute_http_action(
         # (vecchio comportamento) era una violazione silenziosa del contratto:
         # o si perde la richiesta o si prende un 401. Rifiutiamo in modo
         # esplicito finché il secrets store non sarà implementato (roadmap).
+        #
+        # Da settembre 2026 ``_parse_manifest`` rifiuta ``server.auth`` al
+        # caricamento, quindi per la via normale (``load_app`` → ``find_app``)
+        # qui non si arriva più. Il controllo resta perché questa funzione
+        # accetta un ``AppManifest`` qualunque — costruito a mano, o prodotto da
+        # un parser che un domani riammettesse il campo: è l'ultima linea, e
+        # perderla renderebbe il rifiuto una proprietà del validatore invece che
+        # dell'esecutore.
         logger.warning(
             "App '{}' declares server.auth but no credential store is configured; "
             "refusing the action (fail-closed).",

--- a/jenny/apps/manifest.py
+++ b/jenny/apps/manifest.py
@@ -1,10 +1,16 @@
 """Jenny App manifest loading and validation.
 
 An app is a folder in ``<workspace>/apps/<slug>/`` with an ``app.json``
-manifest declaring typed actions (see ``.agent/jenny-apps.md`` and the
-``app-creator`` skill reference). Loading never raises: malformed apps come
+manifest optionally declaring typed actions (see ``.agent/jenny-apps.md`` and
+the ``app-creator`` skill reference). Loading never raises: malformed apps come
 back as ``LoadedApp(broken=True, error=...)`` so the grid can show them as
 broken without ever crashing the gateway.
+
+``actions`` is optional: an app whose only job is to draw a screen has nothing
+agent-facing to declare, and requiring a non-empty list made that app
+impossible to write — the observed result was an *invented* action added only to
+satisfy the schema. ``.agent/jenny-apps.md`` always described the agent-facing
+side as something an app "can" carry; the code disagreed until Sept 2026.
 """
 
 from __future__ import annotations
@@ -22,6 +28,12 @@ PLACEHOLDER_RE = re.compile(r"\{([^}]+)\}")
 STORAGE_OPS = {"append", "set", "update", "delete", "query"}
 HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
 MAX_SLUG_LEN = 32
+# Kind ammessi per il blocco ``view``. "external" vuol dire: lo schermo dell'app
+# e' la UI del suo ``server.baseUrl``, servita attraverso il proxy su loopback
+# (``apps/proxy.py``) invece di ``app/index.html``. Esiste perche' la policy
+# cleartext dell'APK rifiuta un iframe verso un ``http://`` non-loopback, quindi
+# "incornicia il mio server" non era esprimibile in nessun modo.
+VIEW_KINDS = {"external"}
 
 
 @dataclass
@@ -47,6 +59,9 @@ class AppManifest:
     server_base_url: str | None = None
     server_auth: dict | None = None
     actions: list[AppAction] = field(default_factory=list)
+    # "external" quando lo schermo dell'app *e'* il suo server, non
+    # ``app/index.html``. None per un'app normale. V. VIEW_KINDS.
+    view_kind: str | None = None
 
 
 @dataclass
@@ -169,13 +184,23 @@ def _parse_manifest(data: object) -> AppManifest:
         base_url = server["baseUrl"]
         if not base_url.startswith(("http://", "https://")):
             raise ValueError("app.json: server.baseUrl must start with http:// or https://")
-        auth = server.get("auth")
-        if auth is not None and isinstance(auth, dict):
-            server_auth = auth
+        if server.get("auth") is not None:
+            # Rifiutato in fase di caricamento, non solo di esecuzione. Il
+            # credential store non esiste (roadmap) e ``execute_http_action`` e'
+            # fail-closed, quindi un manifest con ``auth`` produceva un'app che
+            # passava la validazione, si apriva, e aveva *tutte* le azioni http
+            # morte con un 501 — visibile solo a chi tentava un'azione. Un
+            # contratto irrealizzabile e' un'app rotta, e va detto qui, dove
+            # l'errore finisce sotto gli occhi di chi ha scritto il manifest.
+            raise ValueError(
+                "app.json: server.auth is declared but app-server credentials are not "
+                "supported yet — remove the 'auth' block (every http action would be "
+                "refused with 501)"
+            )
 
-    raw_actions = data.get("actions")
-    if not isinstance(raw_actions, list) or not raw_actions:
-        raise ValueError("app.json: 'actions' must be a non-empty array")
+    raw_actions = data.get("actions") or []
+    if not isinstance(raw_actions, list):
+        raise ValueError("app.json: 'actions' must be an array")
     actions = [
         _parse_action(raw, i, has_server=base_url is not None)
         for i, raw in enumerate(raw_actions)
@@ -185,6 +210,19 @@ def _parse_manifest(data: object) -> AppManifest:
     if dupes:
         raise ValueError(f"app.json: duplicate action names: {dupes}")
 
+    view = data.get("view")
+    view_kind: str | None = None
+    if view is not None:
+        if not isinstance(view, dict):
+            raise ValueError("app.json: 'view' must be an object")
+        view_kind = view.get("kind")
+        if view_kind not in VIEW_KINDS:
+            raise ValueError(
+                f"app.json: view.kind must be one of {sorted(VIEW_KINDS)} (got {view_kind!r})"
+            )
+        if view_kind == "external" and base_url is None:
+            raise ValueError("app.json: view.kind 'external' requires a 'server.baseUrl'")
+
     icon = data.get("icon")
     return AppManifest(
         name=data["name"].strip(),
@@ -193,6 +231,7 @@ def _parse_manifest(data: object) -> AppManifest:
         server_base_url=base_url,
         server_auth=server_auth,
         actions=actions,
+        view_kind=view_kind,
     )
 
 

--- a/jenny/apps/proxy.py
+++ b/jenny/apps/proxy.py
@@ -1,0 +1,393 @@
+"""Reverse proxy su loopback per la "vista esterna" di una Jenny App.
+
+Perche' non e' una route del gateway
+------------------------------------
+Il gateway HTTP gira sul parser di ``websockets`` (``websockets.http11.Request``),
+che legge riga di richiesta e header e **non il body**: e' la stessa ragione per
+cui ``apps/http.py`` documenta la tratta browser→gateway come GET-only. Una UI
+remota reale fa POST, quindi montarla come route del gateway non era possibile.
+
+Secondo motivo, indipendente: sotto un prefisso di path i path assoluti della
+pagina remota (``/style.css``, ``/api/x``) si risolverebbero sulla radice del
+gateway. Servirebbe riscrittura degli URL, che e' fragile per definizione. Un
+listener con **origine propria** li fa funzionare senza toccare un byte.
+
+Perche' su loopback
+-------------------
+La policy di rete dell'APK (``network_security_config.xml``) permette il
+cleartext **solo** verso ``127.0.0.1``/``localhost``: una WebView che incornicia
+un ``http://`` non-loopback prende ``ERR_CLEARTEXT_NOT_PERMITTED`` prima di
+aprire un socket. Passare da loopback rende la policy inapplicabile al caso,
+senza allargarla e senza mettere il nome di un host personale nell'APK.
+
+Il proxy e' trasparente a livello di byte: riscrive la prima riga e l'``Host``,
+poi ristreamma. Quindi ogni metodo, i body, il chunked e l'upgrade WebSocket
+passano senza casi speciali.
+
+Superficie e cosa la limita
+---------------------------
+- bind su ``127.0.0.1`` e porta effimera, mai su un'interfaccia esterna;
+- **un solo upstream fisso**, validato una volta con
+  ``validate_app_server_target``: il proxy non e' pilotabile verso un altro
+  indirizzo, e non segue redirect a livello proprio (li ristreamma al browser,
+  che li risolve sull'origine del proxy);
+- **capability**: la prima navigazione deve presentare un segreto da 128 bit nel
+  path; il proxy risponde 302 e lo sposta in un cookie, cosi' i path assoluti
+  della pagina remota continuano a funzionare. Senza cookie ne' prefisso: 403.
+  Serve perche' ``127.0.0.1:<porta>`` e' raggiungibile da qualunque app del
+  telefono, e una porta effimera si scandaglia in pochi secondi.
+- vive quanto la vista: ``close()`` alla chiusura dell'app, piu' un idle timeout.
+
+Limite noto della capability: i cookie sono per-host e **ignorano la porta**,
+quindi il cookie viaggia verso qualunque server su ``127.0.0.1`` che la WebView
+contatti. In pratica sono solo questo proxy e il gateway (entrambi nostri), ma e'
+il motivo per cui il valore viene **rimosso** dalla richiesta inoltrata: il
+server dell'utente non deve vederlo.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from urllib.parse import urlsplit
+
+from loguru import logger
+
+from jenny.security.network import validate_app_server_target
+
+COOKIE_NAME = "jenny_app_view"
+MAX_HEADER_BYTES = 64 * 1024
+DEFAULT_IDLE_TIMEOUT_S = 30 * 60.0
+_CRLF2 = b"\r\n\r\n"
+
+
+class AppViewProxyError(Exception):
+    """Avvio impossibile: target rifiutato o non interpretabile."""
+
+
+def _split_upstream(base_url: str) -> tuple[str, int, str]:
+    """(host, port, prefisso di path) da un ``server.baseUrl``."""
+    parts = urlsplit(base_url)
+    if parts.scheme not in ("http", "https"):
+        raise AppViewProxyError(f"unsupported scheme: {parts.scheme!r}")
+    if parts.scheme == "https":
+        # Il proxy e' un tunnel di byte in chiaro: verso un upstream TLS
+        # dovrebbe terminare la connessione, che e' un altro sottosistema. Un
+        # server https non ha comunque bisogno di questo proxy — la policy
+        # cleartext non lo tocca, l'iframe lo carica direttamente.
+        raise AppViewProxyError(
+            "https app servers do not need the view proxy: frame the URL directly"
+        )
+    if not parts.hostname:
+        raise AppViewProxyError("baseUrl has no host")
+    return parts.hostname, parts.port or 80, parts.path.rstrip("/")
+
+
+class AppViewProxy:
+    """Un listener su loopback che inoltra a un solo server d'app."""
+
+    def __init__(self, slug: str, base_url: str, *, idle_timeout_s: float = DEFAULT_IDLE_TIMEOUT_S):
+        self.slug = slug
+        self.base_url = base_url
+        self._host, self._port, self._prefix = _split_upstream(base_url)
+        self._cap = secrets.token_urlsafe(16)
+        self._idle_timeout_s = idle_timeout_s
+        self._server: asyncio.AbstractServer | None = None
+        self._bound_port: int | None = None
+        self._conns: set[asyncio.Task] = set()
+        self._idle_task: asyncio.Task | None = None
+        self._last_activity = 0.0
+
+    # ── ciclo di vita ────────────────────────────────────────────────────
+
+    async def start(self) -> str:
+        """Valida il target, apre il listener, torna l'URL d'ingresso."""
+        ok, error = validate_app_server_target(self.base_url)
+        if not ok:
+            raise AppViewProxyError(f"blocked server target: {error}")
+
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self._bound_port = self._server.sockets[0].getsockname()[1]
+        self._touch()
+        self._idle_task = asyncio.create_task(self._reap_when_idle())
+        logger.info(
+            "App '{}' view proxy on 127.0.0.1:{} -> {}",
+            self.slug, self._bound_port, self.base_url,
+        )
+        return self.entry_url
+
+    @property
+    def entry_url(self) -> str:
+        return f"http://127.0.0.1:{self._bound_port}/{self._cap}/"
+
+    @property
+    def port(self) -> int | None:
+        return self._bound_port
+
+    async def close(self) -> None:
+        """Chiude il listener. L'ORDINE dei quattro passi non e' arbitrario.
+
+        ``wait_closed()`` attende che finiscano anche i **gestori** delle
+        connessioni ancora aperte (da 3.12; su 3.11 ritorna subito). Un gestore
+        del proxy sta normalmente appeso su ``read()`` in attesa del prossimo
+        byte, quindi aspettarlo *prima* di cancellarlo e' un deadlock: la
+        chiusura non ritornava mai. Ed e' il caso normale, non un caso limite —
+        l'utente chiude l'app con la pagina caricata e la connessione viva, e la
+        route ``.../view/close`` restava appesa.
+
+        Quindi: prima si smette di accettare, poi si cancellano i gestori, e solo
+        allora si aspetta.
+        """
+        if self._idle_task is not None:
+            self._idle_task.cancel()
+            self._idle_task = None
+        server, self._server = self._server, None
+        if server is not None:
+            server.close()
+        for task in list(self._conns):
+            task.cancel()
+        self._conns.clear()
+        if server is not None:
+            try:
+                await server.wait_closed()
+            except Exception:  # pragma: no cover - chiusura best-effort
+                pass
+        logger.info("App '{}' view proxy closed", self.slug)
+
+    def _touch(self) -> None:
+        self._last_activity = asyncio.get_running_loop().time()
+
+    async def _reap_when_idle(self) -> None:
+        """Chiude il listener dopo un periodo senza traffico.
+
+        Rete di sicurezza, non il meccanismo principale: la chiusura normale la
+        fa la UI quando l'utente chiude l'app. Serve per il caso in cui quel
+        segnale non arrivi (processo della WebUI ucciso, overlay perso), che
+        altrimenti lascerebbe una porta aperta a tempo indefinito.
+        """
+        try:
+            while True:
+                loop = asyncio.get_running_loop()
+                idle = loop.time() - self._last_activity
+                remaining = self._idle_timeout_s - idle
+                if remaining <= 0:
+                    logger.info(
+                        "App '{}' view proxy idle for {:.0f}s, closing", self.slug, idle
+                    )
+                    # Sganciare il riferimento prima di close(), altrimenti
+                    # close() cancella il task corrente — cioe' questo.
+                    #
+                    # **Difensivo, non load-bearing**: con l'ordine dei passi in
+                    # close() l'unico await avviene dopo la cancellazione dei
+                    # gestori e ritorna subito, quindi l'auto-cancellazione non
+                    # trova un punto di sospensione dove scattare. Nessun test
+                    # lo raggiunge (provato: rimuovendo questa riga la suite
+                    # resta verde). Serve perche' basta aggiungere un await
+                    # dentro close() perche' torni a mordere.
+                    self._idle_task = None
+                    await self.close()
+                    return
+                await asyncio.sleep(min(remaining, 60.0))
+        except asyncio.CancelledError:
+            raise
+
+    # ── una connessione ──────────────────────────────────────────────────
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._conns.add(task)
+        try:
+            self._touch()
+            await self._serve_one(reader, writer)
+        except (asyncio.CancelledError, ConnectionResetError, BrokenPipeError):
+            pass
+        except Exception as exc:
+            logger.debug("App '{}' view proxy connection error: {}", self.slug, exc)
+        finally:
+            if task is not None:
+                self._conns.discard(task)
+            _close_quietly(writer)
+
+    async def _serve_one(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        head, rest = await self._read_head(reader)
+        if head is None:
+            return
+        try:
+            request_line, header_lines = _parse_head(head)
+        except ValueError:
+            await _respond(writer, 400, "Bad Request")
+            return
+
+        method, path, version = request_line
+        authorized, redirect_to = self._authorize(path, header_lines)
+        if redirect_to is not None:
+            # Sposta la capability dal path a un cookie e rimanda alla radice:
+            # da qui in avanti i path assoluti della pagina remota funzionano.
+            await _respond(
+                writer, 302, "Found",
+                extra=[
+                    ("Location", redirect_to),
+                    ("Set-Cookie", f"{COOKIE_NAME}={self._cap}; Path=/; HttpOnly; SameSite=Lax"),
+                ],
+            )
+            return
+        if not authorized:
+            await _respond(writer, 403, "Forbidden")
+            return
+
+        upstream_path = self._prefix + path if self._prefix else path
+        out_head = _rebuild_head(
+            method, upstream_path, version, header_lines,
+            host=f"{self._host}:{self._port}" if self._port != 80 else self._host,
+        )
+
+        try:
+            up_reader, up_writer = await asyncio.open_connection(self._host, self._port)
+        except OSError as exc:
+            logger.debug("App '{}' view proxy upstream unreachable: {}", self.slug, exc)
+            await _respond(writer, 502, "Bad Gateway")
+            return
+
+        try:
+            up_writer.write(out_head + rest)
+            await up_writer.drain()
+            await asyncio.gather(
+                self._pump(up_reader, writer),
+                self._pump(reader, up_writer),
+            )
+        finally:
+            _close_quietly(up_writer)
+
+    async def _read_head(
+        self, reader: asyncio.StreamReader
+    ) -> tuple[bytes | None, bytes]:
+        """Legge fino alla fine degli header; torna (head, byte già letti oltre)."""
+        buf = bytearray()
+        while _CRLF2 not in buf:
+            if len(buf) > MAX_HEADER_BYTES:
+                return None, b""
+            chunk = await reader.read(4096)
+            if not chunk:
+                return None, b""
+            buf.extend(chunk)
+        head, _, rest = bytes(buf).partition(_CRLF2)
+        return head, rest
+
+    def _authorize(
+        self, path: str, header_lines: list[tuple[str, str]]
+    ) -> tuple[bool, str | None]:
+        """``(autorizzata, URL a cui reindirizzare per posare il cookie)``.
+
+        Il chiamante gestisce il redirect **prima** dell'inoltro: quando il
+        secondo elemento non e' None la richiesta e' autorizzata ma non va
+        inoltrata, va scambiata con un 302 che sposta la capability nel cookie.
+        """
+        if path == f"/{self._cap}" or path.startswith(f"/{self._cap}/"):
+            stripped = path[len(self._cap) + 1:] or "/"
+            return True, stripped if stripped.startswith("/") else "/" + stripped
+        for name, value in header_lines:
+            if name.lower() == "cookie" and _cookie_value(value, COOKIE_NAME) == self._cap:
+                return True, None
+        return False, None
+
+    async def _pump(self, src: asyncio.StreamReader, dst: asyncio.StreamWriter) -> None:
+        try:
+            while True:
+                chunk = await src.read(65536)
+                if not chunk:
+                    break
+                self._touch()
+                dst.write(chunk)
+                await dst.drain()
+        except (ConnectionResetError, BrokenPipeError, asyncio.IncompleteReadError):
+            pass
+        finally:
+            try:
+                dst.write_eof()
+            except Exception:
+                pass
+
+
+# ── helper di protocollo ─────────────────────────────────────────────────
+
+
+def _close_quietly(writer: asyncio.StreamWriter) -> None:
+    """Chiude uno writer senza propagare: la chiusura non e' mai la notizia."""
+    try:
+        writer.close()
+    except Exception:
+        pass
+
+
+def _parse_head(head: bytes) -> tuple[tuple[str, str, str], list[tuple[str, str]]]:
+    lines = head.decode("latin-1").split("\r\n")
+    parts = lines[0].split(" ")
+    if len(parts) != 3:
+        raise ValueError("malformed request line")
+    headers: list[tuple[str, str]] = []
+    for line in lines[1:]:
+        if not line:
+            continue
+        name, sep, value = line.partition(":")
+        if not sep:
+            raise ValueError("malformed header line")
+        headers.append((name.strip(), value.strip()))
+    return (parts[0], parts[1], parts[2]), headers
+
+
+def _rebuild_head(
+    method: str, path: str, version: str, headers: list[tuple[str, str]], *, host: str
+) -> bytes:
+    out = [f"{method} {path} {version}"]
+    for name, value in headers:
+        low = name.lower()
+        if low == "host":
+            continue
+        if low == "cookie":
+            # La capability non deve raggiungere il server dell'utente: e' un
+            # segreto nostro, e i cookie ignorano la porta (v. docstring).
+            cleaned = _strip_cookie(value, COOKIE_NAME)
+            if not cleaned:
+                continue
+            value = cleaned
+        out.append(f"{name}: {value}")
+    out.append(f"Host: {host}")
+    return ("\r\n".join(out) + "\r\n\r\n").encode("latin-1")
+
+
+def _cookie_value(header: str, name: str) -> str | None:
+    for item in header.split(";"):
+        key, sep, value = item.strip().partition("=")
+        if sep and key == name:
+            return value
+    return None
+
+
+def _strip_cookie(header: str, name: str) -> str:
+    kept = []
+    for item in header.split(";"):
+        key, sep, _ = item.strip().partition("=")
+        if sep and key == name:
+            continue
+        if item.strip():
+            kept.append(item.strip())
+    return "; ".join(kept)
+
+
+async def _respond(
+    writer: asyncio.StreamWriter,
+    status: int,
+    reason: str,
+    *,
+    extra: list[tuple[str, str]] | None = None,
+) -> None:
+    lines = [f"HTTP/1.1 {status} {reason}"]
+    for name, value in extra or []:
+        lines.append(f"{name}: {value}")
+    lines += ["Content-Length: 0", "Connection: close", "", ""]
+    writer.write("\r\n".join(lines).encode("latin-1"))
+    try:
+        await writer.drain()
+    except Exception:
+        pass

--- a/jenny/apps/summary.py
+++ b/jenny/apps/summary.py
@@ -21,12 +21,17 @@ def build_apps_summary(workspace: Path) -> str:
                 f"Fix `apps/{app.slug}/app.json` if the user asks."
             )
             continue
-        tools = ", ".join(f"`{app.slug}_{a.name}`" for a in app.manifest.actions)
-        line = (
-            f"- **{app.manifest.name}** (`{app.slug}`) — {app.manifest.description} "
-            f"— tools: {tools} — data: `apps/{app.slug}/data/`"
-        )
+        # Composta a pezzi perche' le azioni sono opzionali: un'app di sola
+        # visualizzazione ne ha zero, e un `— tools: ` vuoto in mezzo alla riga
+        # sembrerebbe un elenco che non e' stato caricato.
+        parts = [f"- **{app.manifest.name}** (`{app.slug}`) — {app.manifest.description}"]
+        if app.manifest.actions:
+            tools = ", ".join(f"`{app.slug}_{a.name}`" for a in app.manifest.actions)
+            parts.append(f"tools: {tools}")
+        else:
+            parts.append("no agent-facing actions (display-only app)")
+        parts.append(f"data: `apps/{app.slug}/data/`")
         if (app.dir / "AGENT.md").is_file():
-            line += f" — context: `apps/{app.slug}/AGENT.md`"
-        lines.append(line)
+            parts.append(f"context: `apps/{app.slug}/AGENT.md`")
+        lines.append(" — ".join(parts))
     return "\n".join(lines)

--- a/jenny/providers/anthropic_provider.py
+++ b/jenny/providers/anthropic_provider.py
@@ -26,6 +26,7 @@ from jenny.providers.base import (
     LLMProvider,
     LLMResponse,
     ToolCallRequest,
+    describe_exc,
     parse_tool_arguments,
 )
 from jenny.providers.body_merge import deep_merge
@@ -117,7 +118,7 @@ class AnthropicProvider(AnthropicConversionMixin, LLMProvider):
                 except Exception:
                     payload = None
         payload_text = payload if isinstance(payload, str) else str(payload) if payload is not None else ""
-        msg = f"Error: {payload_text.strip()[:500]}" if payload_text.strip() else f"Error calling LLM: {e}"
+        msg = f"Error: {payload_text.strip()[:500]}" if payload_text.strip() else f"Error calling LLM: {describe_exc(e)}"
         retry_after = cls._extract_retry_after_from_headers(headers)
         if retry_after is None:
             retry_after = LLMProvider._extract_retry_after(msg)
@@ -584,7 +585,7 @@ class AnthropicProvider(AnthropicConversionMixin, LLMProvider):
             # this only adds partial_content when the stream had already
             # produced text before crashing (#audit mid-stream-exception loss).
             return LLMResponse(
-                content=f"Error calling LLM: {exc}",
+                content=f"Error calling LLM: {describe_exc(exc)}",
                 finish_reason="error",
                 partial_content="".join(content_parts) or None,
             )

--- a/jenny/providers/base.py
+++ b/jenny/providers/base.py
@@ -102,6 +102,21 @@ class ToolCallRequest:
         return tool_call
 
 
+def describe_exc(exc: BaseException) -> str:
+    """Descrizione non vuota di un'eccezione, per i messaggi d'errore utente.
+
+    ``str(exc)`` e' vuoto per un'intera famiglia di eccezioni che qui arrivano
+    di continuo: tutti i timeout e gli errori di connessione di httpx
+    (``ReadTimeout``, ``ConnectTimeout``, ``ConnectError``,
+    ``RemoteProtocolError``) si costruiscono senza messaggio, e cosi' fa
+    ``StreamTimeout`` qui sopra. Interpolato in un f-string produceva
+    ``"Error calling LLM: "`` — cioe' l'utente vedeva un errore troncato ai due
+    punti, e nemmeno il log permetteva di risalire alla causa. Il nome della
+    classe e' l'unica informazione che resta, ed e' meglio del nulla.
+    """
+    return str(exc) or type(exc).__name__
+
+
 def parse_tool_arguments(arguments: Any) -> Any:
     """Parse provider tool arguments without guessing executable parameters.
 
@@ -347,7 +362,7 @@ class LLMProvider(ABC):
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            return LLMResponse(content=f"Error calling LLM: {exc}", finish_reason="error")
+            return LLMResponse(content=f"Error calling LLM: {describe_exc(exc)}", finish_reason="error")
 
     async def chat_stream(
         self,
@@ -391,7 +406,7 @@ class LLMProvider(ABC):
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            return LLMResponse(content=f"Error calling LLM: {exc}", finish_reason="error")
+            return LLMResponse(content=f"Error calling LLM: {describe_exc(exc)}", finish_reason="error")
 
     async def chat_stream_with_retry(
         self,

--- a/jenny/providers/openai_compat_provider.py
+++ b/jenny/providers/openai_compat_provider.py
@@ -23,6 +23,7 @@ from jenny.providers.base import (
     LLMResponse,
     ProviderHTTPError,
     StreamTimeout,
+    describe_exc,
     tool_arguments_json_for_replay,
 )
 from jenny.providers.openai_compat_helpers import (
@@ -662,7 +663,7 @@ class OpenAICompatProvider(ResponseParsingMixin, LLMProvider):
         if isinstance(e, ProviderHTTPError):
             # Il suo messaggio nomina già status, URL e un estratto del corpo, che
             # è più di quanto direbbe il solo corpo: non va riscritto.
-            msg = f"Error calling LLM: {e}"
+            msg = f"Error calling LLM: {describe_exc(e)}"
         else:
             try:
                 body = (
@@ -673,7 +674,7 @@ class OpenAICompatProvider(ResponseParsingMixin, LLMProvider):
             except Exception:
                 body = None
             body_text = body if isinstance(body, str) else str(body) if body is not None else ""
-            msg = f"Error: {body_text.strip()[:500]}" if body_text.strip() else f"Error calling LLM: {e}"
+            msg = f"Error: {body_text.strip()[:500]}" if body_text.strip() else f"Error calling LLM: {describe_exc(e)}"
 
         headers = getattr(e, "headers", None)
         if headers is None:

--- a/jenny/security/network.py
+++ b/jenny/security/network.py
@@ -23,11 +23,28 @@ _BLOCKED_NETWORKS = [
 # Blocklist for Jenny App `http` actions: app servers are user-declared LAN
 # devices, so private ranges (RFC1918, IPv6 ULA) are allowed. Loopback stays
 # blocked so an app manifest can't use the proxy as an authenticated bridge to
-# the gateway's own API; link-local/metadata and CGNAT stay blocked too
-# (CGNAT is exemptable via the existing ssrf whitelist, e.g. for Tailscale).
+# the gateway's own API; link-local/metadata and 0.0.0.0/8 stay blocked because
+# they are never a user's server.
+#
+# CGNAT (100.64.0.0/10) is ALLOWED here, same as in _SSH_BLOCKED_NETWORKS and
+# for the same reason: it is the range Tailscale assigns its nodes, and reaching
+# one's own server over Tailscale from a phone on 4G is the normal case, not an
+# exotic one. It used to be blocked, with the escape hatch documented as
+# "exemptable via the existing ssrf whitelist" — but that whitelist is *global*,
+# so opening it to let one app talk to one's own server would have opened CGNAT
+# to `web_fetch` and to every target the model picks. A narrow permission in the
+# policy that needs it beats a wide one across all three.
+#
+# The stated justification for blocking it was that an app manifest must not use
+# the proxy as a bridge to the gateway's own API — but that is the argument for
+# blocking *loopback*, which still is: a CGNAT address does not reach the
+# gateway. The two had been flattened into one sentence.
+#
+# What still stands guard: loopback and link-local blocked, redirects never
+# followed (see apps/http.py), the target declared by the user in a manifest
+# they can read, and only the app's own typed actions able to call it.
 _APP_SERVER_BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("100.64.0.0/10"),   # carrier-grade NAT
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("169.254.0.0/16"),   # link-local / cloud metadata
     ipaddress.ip_network("::1/128"),
@@ -150,10 +167,11 @@ def validate_url_target(url: str, *, allow_loopback: bool = False) -> tuple[bool
 def validate_app_server_target(url: str) -> tuple[bool, str]:
     """Validate a Jenny App server URL (``server.baseUrl`` targets only).
 
-    Unlike :func:`validate_url_target`, RFC1918 and IPv6 ULA ranges are
-    allowed — app servers are user-declared LAN devices. Loopback, link-local
-    metadata, 0.0.0.0/8 and CGNAT stay blocked (see
-    ``_APP_SERVER_BLOCKED_NETWORKS``).
+    Unlike :func:`validate_url_target`, RFC1918, IPv6 ULA **and** CGNAT
+    (Tailscale) are allowed — app servers are user-declared LAN or tailnet
+    devices. Loopback, link-local metadata and 0.0.0.0/8 stay blocked (see
+    ``_APP_SERVER_BLOCKED_NETWORKS`` for why CGNAT is permitted here rather
+    than through the global ssrf whitelist).
 
     Returns (ok, error_message).  When ok is True, error_message is empty.
     """

--- a/jenny/skills/app-creator/SKILL.md
+++ b/jenny/skills/app-creator/SKILL.md
@@ -62,7 +62,7 @@ hand-rolled overlay `<div>`. See "Internal navigation and the Android back butto
 <rule>
 **Follow the Guided Conversation Flow below.** Ask ONE question at a time. Only write files
 AFTER the user has confirmed name and actions in Phase 3.
-Never write real secrets into app.json or index.html — use `secretRef` (see Secrets below).
+Never write real secrets into app.json or index.html, and never declare `server.auth` at all (see Secrets below).
 
 **This conversation is not a sustained goal: do not call `long_task` for it.** Each phase
 ends by asking the user something and waiting, which is the one thing a goal cannot do for
@@ -90,7 +90,7 @@ the agent should be able to do on the user's behalf, becomes one action:
 - Local data (notes, lists, logs) → `storage` actions on collections in `data/`.
 - External server (e.g. a LAN plant server) → `http` actions mapped onto its endpoints.
 
-If an endpoint needs auth, ask for the secret NAME only, never the value (see Secrets).
+If an endpoint needs auth, it cannot be used yet — say so (see Secrets).
 
 ### Phase 3: Propose and Confirm
 
@@ -135,14 +135,18 @@ Then tell the user the app is ready and will appear in the Jenny Apps grid.
 
 ## Secrets
 
-`app.json` must only ever contain `"auth": {"secretRef": "<name>"}`. The actual token lives
-in the gateway secrets store, excluded from agent reads, and is injected by the action proxy
-at call time. Current gateway versions do not implement the store yet and call the server
-without credentials (fine for LAN servers without auth) — still write `secretRef`, never a
-raw token, so manifests keep working when the store lands. When an app needs a token, pick a name (e.g. `piante_token`), put the
-`secretRef` in the manifest, and ask the user to store the value under that name from the
-settings UI. If the user pastes a token in chat, do not echo it and do not write it to any
-file in the workspace.
+**Never write an `auth` block in `app.json` — not even `{"secretRef": "<name>"}`.** The
+credential store is not implemented, and the http executor is fail-closed: a manifest that
+declares `server.auth` has **every** http action refused with 501, and since Sept 2026 the
+app is rejected at load as broken. This section previously said to write `secretRef` anyway
+"so manifests keep working when the store lands"; that advice shipped a real app whose only
+action was dead on arrival, and it is withdrawn.
+
+So: an app can only talk to an endpoint that needs no credentials (a LAN or Tailscale server
+without auth is the normal case). If the user's endpoint *does* need a token, say plainly
+that Jenny Apps cannot authenticate to an app server yet, and do not write a manifest that
+pretends otherwise. Never put a raw token in `app.json` or `index.html`. If the user pastes a
+token in chat, do not echo it and do not write it to any file in the workspace.
 
 ## Boundaries
 

--- a/jenny/skills/app-creator/references/manifest.md
+++ b/jenny/skills/app-creator/references/manifest.md
@@ -11,8 +11,20 @@ Contents: [app.json fields](#appjson-fields) · [storage actions](#storage-actio
 | `name` | yes | Display name shown in the Jenny Apps grid |
 | `description` | yes | One line: what the app does (shown in the grid and to the agent) |
 | `icon` | no | Tabler icon name (e.g. `ti-plant`); defaults to `ti-apps` |
-| `server` | no | Only for apps backed by an external API: `{"baseUrl": "...", "auth": {"secretRef": "..."}}` |
-| `actions` | yes | Array of typed actions (the contract — see below) |
+| `server` | no | Only for apps backed by an external API: `{"baseUrl": "..."}` |
+| `actions` | no | Array of typed actions (the contract — see below). Omit it for a display-only app |
+| `view` | no | `{"kind": "external"}` — the app's screen is its server's UI, not `app/index.html` |
+
+> **Never declare `server.auth`.** There is no credential store yet, and the http executor is
+> fail-closed: with `auth` present, **every** http action is refused with 501, and since
+> Sept 2026 the app is rejected at load as broken. This table used to show
+> `"auth": {"secretRef": "..."}` as part of `server`, which is how a real app came to declare
+> it and ship dead. Point the `baseUrl` at an endpoint that needs no credentials.
+
+> **`actions` is optional.** An app whose only job is to draw a screen has nothing
+> agent-facing to declare — omit `actions` entirely. Do **not** invent a filler action (a
+> health-check ping, a no-op query) to satisfy the schema: that happened, and it produced an
+> app with a permanently broken tool the user never asked for.
 
 Fields common to every action:
 
@@ -84,8 +96,8 @@ notes.forEach(...)
 
 ## http actions
 
-Mapped onto calls to `server.baseUrl`, executed through the gateway proxy (SSRF-checked,
-auth injected from the secrets store — see Secrets in SKILL.md).
+Mapped onto calls to `server.baseUrl`, executed through the gateway proxy (SSRF-checked; no
+credentials are ever attached — see Secrets in SKILL.md).
 
 | Extra field | Required | Notes |
 |-------------|----------|-------|
@@ -110,6 +122,34 @@ status, `data` is the server's JSON, parsed). Read the payload from `.data`:
 const { data: piante } = await jenny.action('lista_piante');
 ```
 
+## External view (`view: {"kind": "external"}`)
+
+When the user asks for an app that just **shows an existing web UI on their own server**, this
+is the shape — do not write an `index.html` with an `<iframe>` pointing at it:
+
+```json
+{ "name": "Telecomando", "description": "Il telecomando del server di casa",
+  "icon": "ti-device-tv",
+  "server": { "baseUrl": "http://192.168.1.50:8091" },
+  "view": { "kind": "external" } }
+```
+
+No `app/index.html`, no `actions`. The gateway serves the server's UI through a loopback proxy
+and the SPA frames that.
+
+**A hand-written `<iframe src="http://...">` does NOT work, and fails silently.** The APK's
+network policy permits cleartext only to the local gateway, so the WebView refuses the frame
+with `ERR_CLEARTEXT_NOT_PERMITTED` before any request goes out — the user sees a blank panel.
+That is exactly how one such app shipped looking finished and doing nothing. `view: external`
+is the supported way to express it.
+
+Constraints:
+
+- requires `server.baseUrl`;
+- `http://` only — an `https` server needs no proxy, frame it directly;
+- the server must be reachable from the phone when the app is opened (LAN, or Tailscale — the
+  SSRF policy allows both). If it is not, say so rather than adding a "ping" action to check.
+
 ## Complete example
 
 ```json
@@ -117,7 +157,7 @@ const { data: piante } = await jenny.action('lista_piante');
   "name": "Piante",
   "description": "Monitoraggio piante di casa: umidità, stato, diario delle cure",
   "icon": "ti-plant",
-  "server": { "baseUrl": "http://192.168.1.50:8080", "auth": { "secretRef": "piante_token" } },
+  "server": { "baseUrl": "http://192.168.1.50:8080" },
   "actions": [
     { "name": "lista_piante", "description": "Elenco piante con stato",
       "kind": "http", "method": "GET", "path": "/plants" },

--- a/jenny/skills/app-creator/scripts/validate_app.py
+++ b/jenny/skills/app-creator/scripts/validate_app.py
@@ -109,14 +109,14 @@ def find_raw_secrets(node, path, errors):
     if isinstance(node, dict):
         for key, value in node.items():
             child = f"{path}.{key}" if path else key
-            if (
-                key.lower() in SECRET_KEYS
-                and key != "secretRef"
-                and isinstance(value, str)
-                and value.strip()
-            ):
+            # Nessuna eccezione per `secretRef`: non e' piu' un campo ammesso
+            # (v. il rifiuto di server.auth sopra), e "secretref" non e'
+            # comunque in SECRET_KEYS — la condizione non scattava mai e
+            # lasciava credere che quella forma fosse ancora sanzionata.
+            if key.lower() in SECRET_KEYS and isinstance(value, str) and value.strip():
                 errors.append(
-                    f"{child}: looks like a raw secret — use \"auth\": {{\"secretRef\": \"<name>\"}} instead"
+                    f"{child}: looks like a raw secret — an app server must not need credentials "
+                    "(app-server auth is not supported); point baseUrl at an open endpoint"
                 )
             find_raw_secrets(value, child, errors)
     elif isinstance(node, list):
@@ -159,20 +159,58 @@ def validate_app(app_dir):
             has_server = True
             if not server["baseUrl"].startswith(("http://", "https://")):
                 errors.append("app.json: server.baseUrl must start with http:// or https://")
+            if server.get("auth") is not None:
+                # Il gateway non ha un credential store e l'esecutore http e'
+                # fail-closed: un'app con `auth` si apre e ha tutte le azioni
+                # http morte con un 501. Va detto qui, mentre il manifest si
+                # scrive, non scoperto tentando un'azione.
+                errors.append(
+                    "app.json: server.auth is declared but app-server credentials are "
+                    "not supported yet — remove the 'auth' block (every http action "
+                    "would be refused with 501)"
+                )
 
     find_raw_secrets(manifest, "app.json", errors)
 
-    actions = manifest.get("actions")
-    if not isinstance(actions, list) or not actions:
-        errors.append("app.json: 'actions' must be a non-empty array")
-    else:
+    actions = manifest.get("actions") or []
+    if not isinstance(actions, list):
+        errors.append("app.json: 'actions' must be an array")
+    elif actions:
         names = [validate_action(a, i, has_server, errors, warnings) for i, a in enumerate(actions)]
         dupes = {n for n in names if n and names.count(n) > 1}
         if dupes:
             errors.append(f"app.json: duplicate action names: {sorted(dupes)}")
 
+    view = manifest.get("view")
+    external_view = False
+    if view is not None:
+        if not isinstance(view, dict):
+            errors.append("app.json: 'view' must be an object")
+        elif view.get("kind") != "external":
+            errors.append(
+                f"app.json: view.kind must be 'external' (got {view.get('kind')!r})"
+            )
+        else:
+            external_view = True
+            if not has_server:
+                errors.append("app.json: view.kind 'external' requires a 'server.baseUrl'")
+            elif isinstance(server, dict) and str(server.get("baseUrl", "")).startswith("https://"):
+                warnings.append(
+                    "view.kind 'external' with an https baseUrl: the loopback proxy is only "
+                    "needed to get around the cleartext policy — frame the URL directly"
+                )
+
     index_path = app_dir / "app" / "index.html"
-    if not index_path.is_file():
+    if external_view:
+        # Lo schermo di questa app e' la UI del suo server, servita dal proxy su
+        # loopback: non c'e' un `app/index.html` da scrivere, e pretenderlo
+        # avrebbe costretto a un file finto.
+        if index_path.is_file():
+            warnings.append(
+                "app/index.html is present but view.kind is 'external' — it will never be "
+                "shown; delete it or drop the 'view' block"
+            )
+    elif not index_path.is_file():
         errors.append("app/index.html is missing (the UI lives in the app/ subfolder)")
     else:
         html = index_path.read_text(encoding="utf-8", errors="replace")

--- a/jenny/templates/ui/assets/i18n/en.json
+++ b/jenny/templates/ui/assets/i18n/en.json
@@ -589,7 +589,10 @@
     "unavailableWhy": "Unavailable: {reason}",
     "loadFailed": "The list could not be read.",
     "azGuide": "Alphabet guide",
-    "jumpToLetter": "Jump to letter {letter}"
+    "jumpToLetter": "Jump to letter {letter}",
+    "frameCleartextBlocked": "{host} will not load: it is plain http, and the app's network policy allows cleartext only to the local gateway. It needs an https server, or an external-view app.",
+    "frameLoadFailed": "{host} failed to load: {reason}",
+    "viewProxyFailed": "Could not open the external view: {error}"
   },
   "wiki": {
     "home": "Wiki",

--- a/jenny/templates/ui/assets/i18n/it.json
+++ b/jenny/templates/ui/assets/i18n/it.json
@@ -589,7 +589,10 @@
     "unavailableWhy": "Non disponibile: {reason}",
     "loadFailed": "Non è stato possibile leggere l'elenco.",
     "azGuide": "Guida alfabetica",
-    "jumpToLetter": "Vai alla lettera {letter}"
+    "jumpToLetter": "Vai alla lettera {letter}",
+    "frameCleartextBlocked": "{host} non si carica: usa http e la policy di rete dell'app permette il traffico in chiaro solo verso il gateway locale. Servono un server in https, oppure un'app di tipo vista esterna.",
+    "frameLoadFailed": "{host} non si è caricato: {reason}",
+    "viewProxyFailed": "Impossibile aprire la vista esterna: {error}"
   },
   "wiki": {
     "home": "Wiki",

--- a/jenny/templates/ui/assets/mobile-apps.js
+++ b/jenny/templates/ui/assets/mobile-apps.js
@@ -93,6 +93,13 @@ export class AppsController {
     // Bridge from sandboxed app iframes (opaque origin → origin check is
     // meaningless; we validate the source window instead).
     window.addEventListener('message', e => this._onAppMessage(e));
+    /* Un iframe che non carica non dice niente al JS che lo contiene
+       (cross-origin: `onerror` non scatta, `contentDocument` è inaccessibile).
+       L'unico che lo vede è il WebViewClient della shell, che ce lo rigira qui —
+       v. MainActivity.reportSubframeError. Senza questo, una app il cui
+       contenuto non carica è un riquadro bianco e nient'altro, per qualunque
+       causa. */
+    window.addEventListener('jenny-subframe-error', e => this._onSubframeError(e));
     /* Agent-side storage mutations → refresh the open app iframe.
 
        Stream non filtrato per `chat_id`, **e deve restare così**: questi due
@@ -1065,6 +1072,12 @@ export class AppsController {
     if (!api.getSecret()) {
       try { await api.bootstrap(); } catch { return; }
     }
+
+    if (app.view_kind === 'external') {
+      await this._openExternalView(slug, app);
+      return;
+    }
+
     const t = currentTheme();
     const lang = document.documentElement.lang || 'it';
     const src = `/apps/${encodeURIComponent(slug)}/index.html`
@@ -1125,12 +1138,110 @@ export class AppsController {
      le schermate nella history con `pushState`, ognuna lasciava una entry nella
      joint session history del WebView che nemmeno `iframe.remove()` toglieva —
      e dopo la ✕ restavano pressioni di Indietro morte. */
+  /* Vista esterna: lo schermo dell'app è la UI del suo server, servita dal
+     proxy su loopback (jenny/apps/proxy.py). Esiste perché la policy di rete
+     dell'APK rifiuta un iframe verso un `http://` non-loopback, quindi
+     "incornicia il mio server" non era esprimibile in nessun modo. */
+  async _openExternalView(slug, app) {
+    let url;
+    try {
+      const res = await fetch(`/api/webui/apps/${encodeURIComponent(slug)}/view`, {
+        headers: { 'Authorization': `Bearer ${api.getSecret()}` },
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || !body.url) throw new Error(body.error || `HTTP ${res.status}`);
+      url = body.url;
+    } catch (e) {
+      showToast(i18n.t('apps.viewProxyFailed', { error: String(e.message || e) }), 'error');
+      return;
+    }
+
+    this.closeApp();
+    const overlay = document.createElement('div');
+    overlay.className = 'app-frame-overlay';
+    overlay.innerHTML = `
+      <div class="app-frame-header">
+        <span class="app-frame-title">${escapeHtml(app.name || slug)}</span>
+        <button class="app-frame-close" title="${i18n.t('apps.close')}"><i class="ti ti-x"></i></button>
+      </div>
+    `;
+    const iframe = document.createElement('iframe');
+    /* Sandbox più largo che per una app normale, e la differenza è l'ORIGINE,
+       non la fiducia.
+
+       Una app normale è servita DALL'ORIGINE DEL GATEWAY: lasciarle la sua
+       origine naturale (`allow-same-origin`) le darebbe il DOM e il
+       localStorage della SPA e l'API del gateway col token. Per quello lì il
+       sandbox è `allow-scripts` e basta.
+
+       Una vista esterna sta su `http://127.0.0.1:<porta effimera>`: porta
+       diversa → **origine diversa** dal gateway. `allow-same-origin` le
+       restituisce la sua origine, che è quella del proxy e di nessun altro, e
+       la same-origin policy del browser la tiene comunque fuori dalla SPA.
+
+       Senza `allow-same-origin` invece l'origine è opaca e la pagina remota è
+       di fatto morta: cookie bloccati, `localStorage` che solleva, e i suoi
+       stessi `fetch` con `Origin: null`. È anche il motivo per cui questa vista
+       NON può essere un iframe annidato dentro l'app-frame sandboxata: i flag
+       di sandbox si ereditano nei frame figli. */
+    iframe.setAttribute(
+      'sandbox',
+      'allow-scripts allow-same-origin allow-forms allow-popups allow-modals'
+    );
+    iframe.src = url;
+    overlay.appendChild(iframe);
+    overlay.querySelector('.app-frame-close').addEventListener('click', () => this.closeApp());
+
+    document.body.appendChild(overlay);
+    requestAnimationFrame(() => overlay.classList.add('visible'));
+    this._openApp = { slug, overlay, iframe, depth: 1, external: true };
+  }
+
   closeApp() {
     const open = this._openApp;
     if (!open) return;
     this._openApp = null;
     open.overlay.classList.remove('visible');
     setTimeout(() => open.overlay.remove(), 200);
+    /* Il listener del proxy vive quanto la vista: chiuderlo qui è la via
+       normale. Se questo fetch non arriva (processo ucciso, rete interna giù)
+       ci pensa l'idle timeout lato Python — non resta aperto per sempre. */
+    if (open.external) {
+      fetch(`/api/webui/apps/${encodeURIComponent(open.slug)}/view/close`, {
+        headers: { 'Authorization': `Bearer ${api.getSecret()}` },
+      }).catch(() => {});
+    }
+  }
+
+  /* Mostra nella UI il fallimento di un sub-frame dell'app aperta.
+     Chiamato dalla shell Android (MainActivity.reportSubframeError), che è il
+     solo punto del sistema che lo sappia. */
+  _onSubframeError(event) {
+    const open = this._openApp;
+    if (!open) return;
+    const d = event?.detail;
+    if (!d || typeof d !== 'object') return;
+
+    /* `ERR_CLEARTEXT_NOT_PERMITTED` merita il suo messaggio: la causa non è
+       nell'app né nella rete, è la network security config dell'APK, che
+       permette il cleartext solo verso il gateway. Detto come errore generico
+       manda a cercare il guasto dove non è — che è esattamente quello che è
+       successo. */
+    const cleartext = String(d.description || '').includes('ERR_CLEARTEXT_NOT_PERMITTED');
+    const host = String(d.host || d.url || '');
+    const message = cleartext
+      ? i18n.t('apps.frameCleartextBlocked', { host })
+      : i18n.t('apps.frameLoadFailed', {
+          host, reason: String(d.description || d.errorCode || ''),
+        });
+
+    let banner = open.overlay.querySelector('.app-frame-error');
+    if (!banner) {
+      banner = document.createElement('div');
+      banner.className = 'app-frame-error';
+      open.overlay.querySelector('.app-frame-header')?.insertAdjacentElement('afterend', banner);
+    }
+    banner.innerHTML = `<i class="ti ti-alert-triangle"></i><span>${escapeHtml(message)}</span>`;
   }
 
   notifyAppDataChanged(slug) {

--- a/jenny/templates/ui/assets/mobile-style.css
+++ b/jenny/templates/ui/assets/mobile-style.css
@@ -3317,6 +3317,22 @@ body {
   color: var(--text-muted); font-size: 20px; padding: 4px 8px;
 }
 .app-frame-overlay iframe { flex: 1; width: 100%; border: 0; background: transparent; }
+/* Fascia d'errore di un sub-frame che non ha caricato. Sta *sotto* l'header e
+   sopra l'iframe: il riquadro bianco resta visibile (è l'informazione che
+   l'utente sta già guardando), ma smette di essere l'unica cosa che dice. */
+.app-frame-error {
+  display: flex; align-items: flex-start; gap: 8px;
+  padding: 10px 14px;
+  background: var(--danger-bg, rgba(220, 80, 80, 0.12));
+  border-bottom: 1px solid var(--border);
+  color: var(--text); font-size: 13px; line-height: 1.4;
+}
+.app-frame-error i { flex: none; margin-top: 1px; color: var(--danger, #d85050); }
+.app-frame-error code {
+  font-size: 12px; word-break: break-all;
+  background: var(--code-bg, rgba(127, 127, 127, 0.14));
+  padding: 1px 4px; border-radius: 3px;
+}
 
 /* ══ Launcher sheet — il cassetto delle app ═══════════════════════════════
    Sale dal basso sopra la vista corrente e si apre dal pulsante nella riga del

--- a/jenny/webui/apps_api.py
+++ b/jenny/webui/apps_api.py
@@ -32,6 +32,10 @@ def list_apps_payload(workspace: Path) -> dict:
                     "description": app.manifest.description,
                     "icon": app.manifest.icon,
                     "has_server": app.manifest.server_base_url is not None,
+                    # La SPA deve saperlo *prima* di aprire: una vista esterna
+                    # non incornicia app/index.html, chiede l'URL del proxy e
+                    # usa un sandbox diverso (v. openApp in mobile-apps.js).
+                    "view_kind": app.manifest.view_kind,
                 }
             )
         else:
@@ -41,6 +45,7 @@ def list_apps_payload(workspace: Path) -> dict:
                     "description": "",
                     "icon": "ti-alert-triangle",
                     "has_server": False,
+                    "view_kind": None,
                 }
             )
         if app.broken:

--- a/jenny/webui/apps_routes.py
+++ b/jenny/webui/apps_routes.py
@@ -49,6 +49,13 @@ class AppsRoutes:
         self._check_api_token = check_api_token
         self._get_workspace_root = get_workspace_root
         self._log = log
+        # slug -> AppViewProxy vivo. Un solo proxy per app: riaprire la stessa
+        # vista riusa il listener invece di lasciarne uno per apertura.
+        #
+        # Non c'e' un hook di shutdown nel container che li chiuda: i listener
+        # sono nel processo del gateway e muoiono con lui, e per il caso in cui
+        # la UI non mandi la chiusura c'e' l'idle timeout del proxy.
+        self._view_proxies: dict[str, Any] = {}
 
     def _check_apps_enabled(self) -> Response | None:
         """Verifica ``config.apps.enabled``, fail-**closed**.
@@ -95,6 +102,12 @@ class AppsRoutes:
         m = re.match(r"^/api/webui/apps/([^/]+)/delete$", path)
         if m:
             return self._delete(request, m.group(1))
+        m = re.match(r"^/api/webui/apps/([^/]+)/view$", path)
+        if m:
+            return await self._view(request, m.group(1))
+        m = re.match(r"^/api/webui/apps/([^/]+)/view/close$", path)
+        if m:
+            return await self._view_close(request, m.group(1))
         m = re.match(r"^/api/apps/([^/]+)/actions/([^/]+)$", path)
         if m:
             return await self._action(request, m.group(1), m.group(2))
@@ -130,6 +143,76 @@ class AppsRoutes:
         except Exception as e:
             self._log.warning("app delete {} failed: {}", slug, e)
             return http_error(500, "internal error")
+
+    def _resolve_view_app(self, raw_slug: str) -> tuple[str, str] | Response:
+        """``(slug, base_url)`` per una vista esterna, o il ``Response`` d'errore."""
+        slug = unquote(raw_slug)
+        if not slug or APP_SLUG_RE.match(slug) is None:
+            return http_error(400, "invalid app slug")
+        from jenny.apps.manifest import find_app
+
+        app = find_app(self._get_workspace_root(), slug)
+        if app is None:
+            return http_error(404, "app not found")
+        if app.broken or app.manifest is None:
+            return http_error(409, f"app is broken: {app.error}")
+        if app.manifest.view_kind != "external":
+            return http_error(400, "app has no external view")
+        if not app.manifest.server_base_url:
+            # _parse_manifest lo garantisce per view.kind 'external'; qui e' per
+            # il type checker e per il caso in cui quella regola cambi.
+            return http_error(409, "external view without a server.baseUrl")
+        return slug, app.manifest.server_base_url
+
+    async def _view(self, request: WsRequest, raw_slug: str) -> Response:
+        """Apre (o riusa) il proxy su loopback e torna l'URL d'ingresso.
+
+        L'URL torna alla SPA, che lo incornicia. Non e' un redirect: la SPA deve
+        vedere l'URL per montare l'iframe con il sandbox giusto (v. openApp).
+        """
+        if not self._check_api_token(request):
+            return http_error(401, "Unauthorized")
+        disabled = self._check_apps_enabled()
+        if disabled is not None:
+            return disabled
+        resolved = self._resolve_view_app(raw_slug)
+        if isinstance(resolved, Response):
+            return resolved
+        slug, base_url = resolved
+
+        existing = self._view_proxies.get(slug)
+        if existing is not None and existing.base_url == base_url:
+            return http_json_response({"url": existing.entry_url}, extra_headers=APP_CORS_HEADERS)
+        if existing is not None:
+            # Il baseUrl e' cambiato sotto: il vecchio listener punta altrove.
+            await existing.close()
+            self._view_proxies.pop(slug, None)
+
+        from jenny.apps.proxy import AppViewProxy, AppViewProxyError
+
+        try:
+            proxy = AppViewProxy(slug, base_url)
+            url = await proxy.start()
+        except AppViewProxyError as exc:
+            return http_json_response({"ok": False, "error": str(exc)}, status=403,
+                                      extra_headers=APP_CORS_HEADERS)
+        except OSError as exc:
+            self._log.warning("app view proxy for {} failed to bind: {}", slug, exc)
+            return http_error(500, "internal error")
+        self._view_proxies[slug] = proxy
+        return http_json_response({"url": url}, extra_headers=APP_CORS_HEADERS)
+
+    async def _view_close(self, request: WsRequest, raw_slug: str) -> Response:
+        """Chiude il listener quando la UI chiude la vista."""
+        if not self._check_api_token(request):
+            return http_error(401, "Unauthorized")
+        slug = unquote(raw_slug)
+        if not slug or APP_SLUG_RE.match(slug) is None:
+            return http_error(400, "invalid app slug")
+        proxy = self._view_proxies.pop(slug, None)
+        if proxy is not None:
+            await proxy.close()
+        return http_json_response({"ok": True}, extra_headers=APP_CORS_HEADERS)
 
     async def _action(self, request: WsRequest, raw_slug: str, raw_action: str) -> Response:
         def respond(payload: dict, status: int) -> Response:

--- a/jenny/webui/ws_http.py
+++ b/jenny/webui/ws_http.py
@@ -803,6 +803,24 @@ class GatewayHTTPHandler:
                 "default-src 'self'; script-src 'self'; "
                 "style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; "
                 "font-src 'self'; connect-src 'self' ws: wss:; "
+                # La vista esterna di una Jenny App e' servita dal proxy su
+                # loopback (``apps/proxy.py``) su una porta EFFIMERA, quindi e'
+                # un'altra origine e non e' 'self'. Senza questa direttiva
+                # ricadeva su ``default-src 'self'`` e la CSP della shell
+                # bloccava il proxio della shell stessa:
+                # ``net::ERR_BLOCKED_BY_CSP``, misurato sul device il 01/09/2026.
+                # La porta non e' prevedibile qui (l'header si scrive servendo
+                # index.html, prima che un proxy esista), da cui il carattere
+                # jolly sulla sola porta.
+                #
+                # Cosa concede: la shell puo' incorniciare qualunque porta di
+                # 127.0.0.1. La CSP qui e' defense-in-depth contro
+                # un'iniezione nella SPA, e per un'iniezione le porte loopback
+                # del telefono non sono un canale di esfiltrazione — sono sulla
+                # stessa macchina su cui gia' gira. Le direttive che contano
+                # contro quello scenario (``script-src``, ``connect-src``,
+                # ``object-src``, ``base-uri``) restano intatte.
+                "frame-src 'self' http://127.0.0.1:*; "
                 "object-src 'none'; base-uri 'none'",
             ))
         return _http_response(

--- a/tests/apps/test_manifest.py
+++ b/tests/apps/test_manifest.py
@@ -19,7 +19,7 @@ VALID_MANIFEST = {
     "name": "Piante",
     "description": "Monitoraggio piante",
     "icon": "ti-plant",
-    "server": {"baseUrl": "http://192.168.1.50:8080", "auth": {"secretRef": "piante_token"}},
+    "server": {"baseUrl": "http://192.168.1.50:8080"},
     "actions": [
         {"name": "lista_piante", "description": "Elenco", "kind": "http",
          "method": "GET", "path": "/plants"},
@@ -49,10 +49,91 @@ class TestLoadApp:
         assert app.manifest.name == "Piante"
         assert app.manifest.icon == "ti-plant"
         assert app.manifest.server_base_url == "http://192.168.1.50:8080"
-        assert app.manifest.server_auth == {"secretRef": "piante_token"}
+        assert app.manifest.server_auth is None
         assert [a.name for a in app.manifest.actions] == ["lista_piante", "umidita", "annota"]
         assert app.manifest.actions[2].op == "append"
         assert app.manifest.actions[2].collection == "cure"
+
+    def test_display_only_app_needs_no_actions(self, tmp_path):
+        """Un'app che disegna solo uno schermo non ha niente da dichiarare.
+
+        Il vincolo `actions` non vuoto ha prodotto in produzione un'azione
+        *inventata* (un ping verso il server, mai chiesto da nessuno) messa
+        lì solo per far passare lo schema. `.agent/jenny-apps.md` ha sempre
+        detto che il lato agente è qualcosa che un'app "can" avere.
+        """
+        for manifest in (
+            {"name": "Vista", "description": "Solo uno schermo"},          # assente
+            {"name": "Vista", "description": "Solo uno schermo", "actions": []},  # vuoto
+        ):
+            app = load_app(_write_app(tmp_path, "vista", manifest))
+            assert not app.broken, app.error
+            assert app.manifest.actions == []
+
+    def test_actions_must_still_be_a_list(self, tmp_path):
+        """Ammettere il vuoto non deve ammettere il tipo sbagliato."""
+        manifest = {"name": "X", "description": "Y", "actions": "annota"}
+        app = load_app(_write_app(tmp_path, "tipo", manifest))
+        assert app.broken
+        assert "'actions' must be an array" in app.error
+
+    def test_server_auth_is_rejected_at_load(self, tmp_path):
+        """Un'app con `server.auth` è rotta, non silenziosamente mezza viva.
+
+        Non esiste un credential store, e `execute_http_action` è fail-closed:
+        con `auth` dichiarato *tutte* le azioni http rispondono 501. Prima
+        l'app passava la validazione, si apriva, e il difetto si scopriva solo
+        tentando un'azione — che è come è finito in produzione.
+        """
+        manifest = dict(VALID_MANIFEST)
+        manifest["server"] = {
+            "baseUrl": "http://192.168.1.50:8080",
+            "auth": {"secretRef": "piante_token"},
+        }
+        app = load_app(_write_app(tmp_path, "conauth", manifest))
+        assert app.broken
+        assert "server.auth" in app.error
+        # L'errore deve nominare il rimedio: è l'unica cosa che chi lo legge
+        # può fare, e senza dirlo il messaggio manda a cercare il credential store.
+        assert "remove the 'auth' block" in app.error
+
+    def test_external_view_loads(self, tmp_path):
+        """La forma che rende esprimibile "incornicia il mio server".
+
+        Prima non lo era: un iframe verso un `http://` non-loopback viene
+        rifiutato dalla policy di rete dell'APK, e nessun campo del manifest
+        poteva dire "questo schermo sta altrove".
+        """
+        manifest = {
+            "name": "Telecomando", "description": "Il telecomando di hps",
+            "server": {"baseUrl": "http://hps:8091"},
+            "view": {"kind": "external"},
+        }
+        app = load_app(_write_app(tmp_path, "telecomando", manifest))
+        assert not app.broken, app.error
+        assert app.manifest.view_kind == "external"
+        assert app.manifest.actions == []  # una vista non ha bisogno di azioni
+
+    def test_external_view_requires_a_server(self, tmp_path):
+        manifest = {"name": "X", "description": "y", "view": {"kind": "external"}}
+        app = load_app(_write_app(tmp_path, "senzaserver", manifest))
+        assert app.broken
+        assert "requires a 'server.baseUrl'" in app.error
+
+    def test_unknown_view_kind_is_rejected(self, tmp_path):
+        """Un kind mistyped non deve diventare silenziosamente un'app normale."""
+        manifest = {
+            "name": "X", "description": "y",
+            "server": {"baseUrl": "http://h:1"},
+            "view": {"kind": "externl"},
+        }
+        app = load_app(_write_app(tmp_path, "typo", manifest))
+        assert app.broken
+        assert "view.kind" in app.error
+
+    def test_no_view_block_means_a_normal_app(self, tmp_path):
+        app = load_app(_write_app(tmp_path, "piante", VALID_MANIFEST))
+        assert app.manifest.view_kind is None
 
     def test_malformed_json_is_broken_not_raised(self, tmp_path):
         app_dir = _write_app(tmp_path, "rotta", "{not json")

--- a/tests/apps/test_proxy.py
+++ b/tests/apps/test_proxy.py
@@ -1,0 +1,336 @@
+"""Il proxy su loopback per la vista esterna di una Jenny App.
+
+Esiste perche' la policy di rete dell'APK rifiuta un iframe verso un ``http://``
+non-loopback (``ERR_CLEARTEXT_NOT_PERMITTED``), e perche' il gateway non puo'
+fare da reverse proxy: gira sul parser di ``websockets``, che non legge il body.
+
+I test si dividono in due famiglie, e la divisione e' deliberata:
+
+- il **cancello** (SSRF, scheme) provato con il validatore vero;
+- il **trasporto** provato con il validatore sostituito, perche' un upstream di
+  prova sta su 127.0.0.1 e il validatore vero — giustamente — lo blocca.
+
+Il primo gruppo contiene un test che verifica che il cancello venga *chiamato*,
+cosi' sostituirlo negli altri non puo' nascondere una sua rimozione.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from jenny.apps import proxy as proxy_mod
+from jenny.apps.proxy import COOKIE_NAME, AppViewProxy, AppViewProxyError
+
+# ── il cancello ──────────────────────────────────────────────────────────
+
+
+async def test_loopback_upstream_is_refused():
+    """Il gateway vive su loopback: un'app non deve poterlo incorniciare."""
+    p = AppViewProxy("x", "http://127.0.0.1:9")
+    with pytest.raises(AppViewProxyError, match="blocked server target"):
+        await p.start()
+
+
+async def test_https_upstream_is_refused_with_a_useful_reason():
+    """Un server https non ha bisogno di questo proxy, e il messaggio lo dice."""
+    with pytest.raises(AppViewProxyError, match="do not need the view proxy"):
+        AppViewProxy("x", "https://example.com")
+
+
+async def test_start_actually_consults_the_ssrf_gate(monkeypatch):
+    """Il cancello deve essere interrogato, non solo esistere.
+
+    Gli altri test lo sostituiscono per poter usare un upstream su 127.0.0.1:
+    senza questo, togliere la chiamata da ``start()`` li lascerebbe tutti verdi.
+    """
+    calls = []
+
+    def _fake(url):
+        calls.append(url)
+        return False, "nope"
+
+    monkeypatch.setattr(proxy_mod, "validate_app_server_target", _fake)
+    p = AppViewProxy("x", "http://plant.lan:8080")
+    with pytest.raises(AppViewProxyError):
+        await p.start()
+    assert calls == ["http://plant.lan:8080"]
+
+
+# ── il trasporto ─────────────────────────────────────────────────────────
+
+
+class _Upstream:
+    """Server di prova: risponde riportando cosa ha ricevuto."""
+
+    def __init__(self):
+        self.server = None
+        self.port = None
+        self.seen: list[bytes] = []
+
+    async def start(self):
+        self.server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self.server.sockets[0].getsockname()[1]
+        return self.port
+
+    async def _handle(self, reader, writer):
+        buf = bytearray()
+        while b"\r\n\r\n" not in buf:
+            chunk = await reader.read(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+        head, _, rest = bytes(buf).partition(b"\r\n\r\n")
+        # Legge il body dichiarato, se c'e'.
+        length = 0
+        for line in head.decode("latin-1").split("\r\n")[1:]:
+            name, _, value = line.partition(":")
+            if name.strip().lower() == "content-length":
+                length = int(value.strip() or 0)
+        body = bytearray(rest)
+        while len(body) < length:
+            chunk = await reader.read(length - len(body))
+            if not chunk:
+                break
+            body.extend(chunk)
+        self.seen.append(bytes(head) + b"\r\n\r\n" + bytes(body))
+        payload = b"UPSTREAM-OK"
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+            % (len(payload), payload)
+        )
+        await writer.drain()
+        writer.close()
+
+    async def close(self):
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()
+
+
+@pytest.fixture
+async def wired(monkeypatch):
+    """(proxy avviato, upstream) con il cancello SSRF sostituito."""
+    monkeypatch.setattr(proxy_mod, "validate_app_server_target", lambda url: (True, ""))
+    up = _Upstream()
+    port = await up.start()
+    p = AppViewProxy("telecomando", f"http://127.0.0.1:{port}")
+    await p.start()
+    try:
+        yield p, up
+    finally:
+        await p.close()
+        await up.close()
+
+
+async def _raw(port: int, request: bytes) -> bytes:
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(request)
+    await writer.drain()
+    out = await asyncio.wait_for(reader.read(-1), timeout=5)
+    writer.close()
+    return out
+
+
+async def test_binds_only_on_loopback(wired):
+    p, _ = wired
+    host, port = p._server.sockets[0].getsockname()[:2]
+    assert host == "127.0.0.1", "il listener non deve stare su un'interfaccia esterna"
+    assert port == p.port
+
+
+async def test_request_without_capability_is_forbidden(wired):
+    p, up = wired
+    out = await _raw(p.port, b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+    assert b"403" in out.split(b"\r\n")[0]
+    assert up.seen == [], "una richiesta non autorizzata non deve raggiungere il server"
+
+
+async def test_capability_path_redirects_and_sets_the_cookie(wired):
+    """La capability passa dal path a un cookie.
+
+    Serve perche' un prefisso di path romperebbe i path assoluti della pagina
+    remota (`/style.css` si risolverebbe fuori dal prefisso). Col cookie
+    l'origine e' la radice e i path assoluti funzionano.
+    """
+    p, up = wired
+    out = await _raw(p.port, f"GET /{p._cap}/ HTTP/1.1\r\nHost: x\r\n\r\n".encode())
+    head = out.decode("latin-1")
+    assert "302" in head.split("\r\n")[0]
+    assert f"{COOKIE_NAME}={p._cap}" in head
+    assert "Path=/" in head and "HttpOnly" in head
+    assert "Location: /" in head
+    assert up.seen == [], "il redirect non deve toccare il server"
+
+
+async def test_cookie_authorizes_and_the_request_is_forwarded(wired):
+    p, up = wired
+    out = await _raw(
+        p.port,
+        f"GET /style.css HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+        f"Cookie: {COOKIE_NAME}={p._cap}\r\n\r\n".encode(),
+    )
+    assert b"UPSTREAM-OK" in out
+    assert len(up.seen) == 1
+    got = up.seen[0].decode("latin-1")
+    assert got.startswith("GET /style.css HTTP/1.1")
+
+
+async def test_capability_is_stripped_before_reaching_the_users_server(wired):
+    """Il segreto e' nostro: il server dell'utente non deve vederlo.
+
+    I cookie sono per-host e ignorano la porta, quindi il browser lo manda a
+    qualunque cosa su 127.0.0.1; qui e' dove la catena si interrompe.
+    """
+    p, up = wired
+    await _raw(
+        p.port,
+        f"GET /x HTTP/1.1\r\nHost: h\r\n"
+        f"Cookie: {COOKIE_NAME}={p._cap}; sid=abc\r\n\r\n".encode(),
+    )
+    got = up.seen[0].decode("latin-1")
+    assert p._cap not in got
+    assert COOKIE_NAME not in got
+    assert "sid=abc" in got, "gli altri cookie della pagina devono passare"
+
+
+async def test_post_with_a_body_passes_through(wired):
+    """La ragione per cui il proxy non e' una route del gateway.
+
+    Il parser di ``websockets`` non legge il body: un POST non sarebbe potuto
+    passare, e una UI di telecomando reale ne fa.
+    """
+    p, up = wired
+    body = b'{"cmd":"volume_up"}'
+    await _raw(
+        p.port,
+        b"POST /api/cmd HTTP/1.1\r\nHost: h\r\n"
+        b"Cookie: " + COOKIE_NAME.encode() + b"=" + p._cap.encode() + b"\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: %d\r\n\r\n%s" % (len(body), body),
+    )
+    got = up.seen[0]
+    assert got.startswith(b"POST /api/cmd HTTP/1.1")
+    assert body in got
+
+
+async def test_host_header_is_rewritten_to_the_upstream(wired):
+    p, up = wired
+    await _raw(
+        p.port,
+        f"GET /x HTTP/1.1\r\nHost: 127.0.0.1:{p.port}\r\n"
+        f"Cookie: {COOKIE_NAME}={p._cap}\r\n\r\n".encode(),
+    )
+    got = up.seen[0].decode("latin-1")
+    assert f"Host: 127.0.0.1:{up.port}" in got
+    assert f"Host: 127.0.0.1:{p.port}" not in got
+
+
+async def test_two_proxies_get_different_capabilities(monkeypatch):
+    """Il segreto e' per-listener: uno non apre la vista di un'altra app."""
+    monkeypatch.setattr(proxy_mod, "validate_app_server_target", lambda url: (True, ""))
+    a = AppViewProxy("a", "http://127.0.0.1:9001")
+    b = AppViewProxy("b", "http://127.0.0.1:9002")
+    assert a._cap != b._cap
+    assert len(a._cap) >= 20
+
+
+async def test_close_releases_the_port(wired):
+    p, _ = wired
+    port = p.port
+    await p.close()
+    with pytest.raises((ConnectionRefusedError, OSError)):
+        await asyncio.wait_for(asyncio.open_connection("127.0.0.1", port), timeout=5)
+
+
+async def test_malformed_request_line_gets_400_not_a_crash(wired):
+    p, up = wired
+    out = await _raw(p.port, b"GARBAGE\r\nHost: x\r\n\r\n")
+    assert b"400" in out.split(b"\r\n")[0]
+    assert up.seen == []
+
+
+async def test_idle_timeout_actually_closes_the_listener(monkeypatch):
+    """L'idle timeout deve chiudere davvero, non a metà — **con una connessione
+    aperta**, che è la condizione in cui il difetto si manifesta.
+
+    Cosa fissa: l'ordine dei passi in ``close()``. ``wait_closed()`` attende
+    anche i gestori delle connessioni vive (da 3.12), e un gestore del proxy sta
+    normalmente appeso su ``read()``: aspettarlo prima di cancellarlo è un
+    deadlock. Verificato invertendo l'ordine — questo test fallisce.
+
+    Senza la connessione tenuta aperta qui sotto il test passava comunque, quindi
+    quella riga è il test. Su 3.11 (la versione del telefono, Chaquopy)
+    ``wait_closed()`` non sospende e il deadlock non si presenta; su 3.14 e sulla
+    3.12 della CI sì.
+    """
+    monkeypatch.setattr(proxy_mod, "validate_app_server_target", lambda url: (True, ""))
+    up = _Upstream()
+    await up.start()
+    p = AppViewProxy("effimera", f"http://127.0.0.1:{up.port}", idle_timeout_s=0.2)
+    await p.start()
+    port = p.port
+    # Connessione aperta e muta: il gestore resta appeso su read(), quindi
+    # `wait_closed()` ha davvero qualcosa da aspettare.
+    _, idle_writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            if p._server is None:
+                break
+        assert p._server is None, "il reaper non ha portato a termine la chiusura"
+        assert p._conns == set(), "le connessioni non sono state cancellate"
+        with pytest.raises((ConnectionRefusedError, OSError)):
+            await asyncio.wait_for(asyncio.open_connection("127.0.0.1", port), timeout=5)
+    finally:
+        idle_writer.close()
+        await p.close()
+        await up.close()
+
+
+async def test_traffic_keeps_the_listener_alive(monkeypatch):
+    """Il timeout è sull'inattività: chi la sta usando non deve perderla."""
+    monkeypatch.setattr(proxy_mod, "validate_app_server_target", lambda url: (True, ""))
+    up = _Upstream()
+    await up.start()
+    p = AppViewProxy("viva", f"http://127.0.0.1:{up.port}", idle_timeout_s=0.6)
+    await p.start()
+    try:
+        for _ in range(4):
+            await asyncio.sleep(0.2)
+            await _raw(
+                p.port,
+                f"GET /ping HTTP/1.1\r\nHost: h\r\n"
+                f"Cookie: {COOKIE_NAME}={p._cap}\r\n\r\n".encode(),
+            )
+        assert p._server is not None, "il traffico deve rinviare la chiusura"
+    finally:
+        await p.close()
+        await up.close()
+
+
+async def test_close_returns_promptly_with_a_live_connection(monkeypatch):
+    """Il percorso che usa l'utente: chiudere l'app con la pagina caricata.
+
+    La UI chiama `.../view/close` mentre una connessione è ancora aperta — è la
+    norma, non un caso limite. Con `wait_closed()` atteso prima di cancellare i
+    gestori quella chiamata non ritornava mai, e la route restava appesa.
+    Qui il timeout è l'asserzione.
+    """
+    monkeypatch.setattr(proxy_mod, "validate_app_server_target", lambda url: (True, ""))
+    up = _Upstream()
+    await up.start()
+    p = AppViewProxy("aperta", f"http://127.0.0.1:{up.port}")
+    await p.start()
+    _, writer = await asyncio.open_connection("127.0.0.1", p.port)
+    await asyncio.sleep(0.05)
+    assert p._conns, "il gestore della connessione deve essere vivo"
+    try:
+        await asyncio.wait_for(p.close(), timeout=5)
+    except asyncio.TimeoutError:  # pragma: no cover - è il difetto
+        pytest.fail("close() non ritorna con una connessione aperta (deadlock)")
+    finally:
+        writer.close()
+        await up.close()
+    assert p._server is None

--- a/tests/apps/test_summary.py
+++ b/tests/apps/test_summary.py
@@ -44,6 +44,23 @@ class TestBuildAppsSummary:
         # Progressive disclosure: the content itself must never be inlined.
         assert "basilico" not in summary
 
+    def test_display_only_app_line_is_well_formed(self, tmp_path):
+        """Zero azioni non deve produrre un `— tools: ` vuoto in mezzo alla riga.
+
+        Un segmento vuoto si legge come un elenco che non è stato caricato, cioè
+        come un guasto, proprio nel contesto che l'agente usa per decidere se ha
+        un tool a disposizione.
+        """
+        _write_app(tmp_path, slug="vista", manifest={
+            "name": "Vista", "description": "Solo uno schermo",
+        })
+        summary = build_apps_summary(tmp_path)
+        assert "**Vista** (`vista`)" in summary
+        assert "tools: —" not in summary
+        assert "tools:  " not in summary
+        assert "display-only" in summary
+        assert "`apps/vista/data/`" in summary
+
     def test_broken_app_line(self, tmp_path):
         app_dir = tmp_path / "apps" / "rotta"
         app_dir.mkdir(parents=True)

--- a/tests/providers/test_error_message_never_empty.py
+++ b/tests/providers/test_error_message_never_empty.py
@@ -1,0 +1,78 @@
+"""Un errore di rete non deve arrivare all'utente troncato ai due punti.
+
+Misurato in produzione il 01/09/2026: la chat mostrava ``Error calling LLM:`` e
+nient'altro, e logcat riportava la stessa stringa vuota
+(``jenny.agent.loop:_run_agent_loop`` logga ``result.final_content``). La causa
+non era il provider: ``str(exc)`` e' vuoto per *tutta* la famiglia dei timeout e
+degli errori di connessione di httpx, che si costruiscono senza messaggio, e
+``f"...: {exc}"`` non lascia niente dietro i due punti. Su un telefono quella
+famiglia e' il caso normale, non il caso raro.
+
+Il test guarda la promessa, non l'implementazione: qualunque strada porti un
+errore fino all'utente, il messaggio deve nominare *qualcosa* di attribuibile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from jenny.providers.base import StreamTimeout, describe_exc
+
+# La famiglia con ``str()`` vuoto. Non e' un elenco inventato: sono le
+# eccezioni che httpx solleva su una rete mobile che cade, piu' StreamTimeout,
+# che nel suo ``__init__`` chiama ``super().__init__()`` senza argomenti.
+EMPTY_STR_EXCEPTIONS = [
+    httpx.ReadTimeout(""),
+    httpx.ConnectTimeout(""),
+    httpx.WriteTimeout(""),
+    httpx.PoolTimeout(""),
+    httpx.ConnectError(""),
+    httpx.RemoteProtocolError(""),
+    httpx.ReadError(""),
+    asyncio.TimeoutError(),
+    StreamTimeout(30.0, saw_output=False),
+    Exception(),
+]
+
+
+@pytest.mark.parametrize("exc", EMPTY_STR_EXCEPTIONS, ids=lambda e: type(e).__name__)
+def test_the_premise_holds(exc):
+    """Prima di tutto: queste eccezioni hanno davvero ``str()`` vuoto.
+
+    Se httpx un giorno iniziasse a dare un messaggio di default, questo test
+    fallirebbe e direbbe che la premessa del fix e' cambiata — meglio che
+    scoprirlo da un altro test che passa per il motivo sbagliato.
+    """
+    assert str(exc) == "", f"{type(exc).__name__} non ha piu' str() vuoto"
+
+
+@pytest.mark.parametrize("exc", EMPTY_STR_EXCEPTIONS, ids=lambda e: type(e).__name__)
+def test_describe_exc_never_returns_empty(exc):
+    described = describe_exc(exc)
+    assert described, f"{type(exc).__name__} descritta con una stringa vuota"
+    assert described == type(exc).__name__
+
+
+@pytest.mark.parametrize("exc", EMPTY_STR_EXCEPTIONS, ids=lambda e: type(e).__name__)
+def test_user_facing_message_is_not_truncated_at_the_colon(exc):
+    """La forma esatta che l'utente ha visto, e che non deve piu' prodursi."""
+    msg = f"Error calling LLM: {describe_exc(exc)}"
+    assert msg != "Error calling LLM: "
+    assert not msg.rstrip().endswith(":")
+    assert type(exc).__name__ in msg
+
+
+def test_a_real_message_is_left_alone():
+    """Quando l'eccezione ha un messaggio, ``describe_exc`` non lo tocca.
+
+    Il fix non deve sostituire un errore parlante col nome della sua classe:
+    ``ProviderHTTPError`` nomina status, URL ed estratto del corpo, ed e' molto
+    piu' utile di ``ProviderHTTPError``.
+    """
+    assert describe_exc(httpx.ConnectError("Cannot resolve hostname: hps")) == (
+        "Cannot resolve hostname: hps"
+    )
+    assert describe_exc(RuntimeError("429 rate limited")) == "429 rate limited"

--- a/tests/security/test_security_network.py
+++ b/tests/security/test_security_network.py
@@ -220,13 +220,29 @@ def test_app_server_allows_private_lan(ip):
         assert ok, f"App policy should allow {ip}, got: {err}"
 
 
+def test_app_server_allows_tailscale_without_the_global_whitelist():
+    """CGNAT ammesso dalla policy stessa, con whitelist VUOTA.
+
+    Il punto e' proprio la whitelist vuota: prima l'unico modo di far parlare
+    un'app col server dell'utente su Tailscale era metterci 100.64.0.0/10, che
+    e' globale e apriva il CGNAT anche a `web_fetch`. Se un giorno questo test
+    passasse solo con la whitelist popolata, il permesso sarebbe tornato largo.
+    """
+    configure_ssrf_whitelist([])
+    with patch(
+        "jenny.security.network.socket.getaddrinfo",
+        _fake_resolve("hps", ["100.107.97.244"]),
+    ):
+        ok, err = validate_app_server_target("http://hps:8091/")
+        assert ok, f"App policy should allow a Tailscale address, got: {err}"
+
+
 @pytest.mark.parametrize(
     "ip,label",
     [
         ("127.0.0.1", "loopback (gateway self-bridge)"),
         ("169.254.169.254", "link-local / metadata"),
         ("0.0.0.1", "0.0.0.0/8"),
-        ("100.100.1.1", "CGNAT"),
     ],
 )
 def test_app_server_still_blocks_dangerous_ranges(ip, label):
@@ -241,13 +257,18 @@ def test_app_server_blocks_ipv6_loopback():
         assert not ok
 
 
-def test_app_server_cgnat_whitelist_still_honored():
-    """The existing ssrf whitelist (e.g. Tailscale) applies to app servers too."""
-    configure_ssrf_whitelist(["100.64.0.0/10"])
+def test_app_server_whitelist_still_honored():
+    """La ssrf whitelist resta applicata anche alla policy delle app.
+
+    Guardava il CGNAT, che ora la policy ammette da se': misurarlo li' non
+    proverebbe piu' niente (passerebbe con o senza whitelist). Spostato su una
+    fascia che la policy blocca davvero, cioe' link-local.
+    """
+    configure_ssrf_whitelist(["169.254.0.0/16"])
     try:
-        with patch("jenny.security.network.socket.getaddrinfo", _fake_resolve("ts.lan", ["100.100.1.1"])):
-            ok, err = validate_app_server_target("http://ts.lan/x")
-            assert ok, f"Whitelisted CGNAT should be allowed, got: {err}"
+        with patch("jenny.security.network.socket.getaddrinfo", _fake_resolve("ll.lan", ["169.254.10.1"])):
+            ok, err = validate_app_server_target("http://ll.lan/x")
+            assert ok, f"Whitelisted range should be allowed, got: {err}"
     finally:
         configure_ssrf_whitelist([])
 

--- a/tests/security/test_ssrf_extended.py
+++ b/tests/security/test_ssrf_extended.py
@@ -219,7 +219,9 @@ def test_port_is_not_part_of_the_security_boundary():
     [
         ("127.0.0.1", False, False, "loopback: entrambe bloccano"),
         ("169.254.169.254", False, False, "metadata: entrambe bloccano"),
-        ("100.100.1.1", False, False, "CGNAT: entrambe bloccano per default"),
+        ("100.100.1.1", False, True,
+         "CGNAT/Tailscale: url_target blocca (indirizzo scelto dal modello), "
+         "app_server ammette (baseUrl dichiarato nel manifest)"),
         ("10.0.0.5", False, True, "RFC1918: url_target blocca, app_server ammette"),
         ("192.168.50.1", False, True, "RFC1918: url_target blocca, app_server ammette"),
         ("172.20.0.9", False, True, "RFC1918: url_target blocca, app_server ammette"),
@@ -260,20 +262,26 @@ def test_ssh_policy_table(ip, ssh_ok, label):
         assert ok is ssh_ok, f"{label} — {err}"
 
 
-def test_ssh_allows_tailscale_without_opening_cgnat_to_the_model():
-    """Il motivo per cui il CGNAT e permesso *qui* e non nella ssrf_whitelist.
+def test_tailscale_allowed_where_the_user_names_the_target_never_where_the_model_does():
+    """Il criterio che separa le tre policy sul CGNAT, con whitelist vuota.
 
-    Il whitelist e globale: usarlo per Tailscale avrebbe aperto il CGNAT anche a
-    `web_fetch`, dove l'indirizzo lo sceglie il modello. Questo permesso invece
-    non esce dall'SSH.
+    Non e' "SSH si, il resto no": e' **chi sceglie l'indirizzo**. Un host SSH lo
+    digita l'utente in Settings; un `server.baseUrl` lo dichiara l'utente in un
+    manifest che puo' leggere. In entrambi i casi il CGNAT e' il modo normale di
+    raggiungere il proprio server da un telefono in 4G. In `web_fetch` invece
+    l'indirizzo lo sceglie il modello, e li' resta bloccato.
+
+    La whitelist globale resta vuota di proposito: e' esattamente la scorciatoia
+    che avrebbe aperto il CGNAT a tutte e tre insieme.
     """
+    configure_ssrf_whitelist([])
     with patch(
         "jenny.security.network.socket.getaddrinfo",
         _fake_resolve("ts.example", ["100.124.67.77"]),
     ):
-        assert validate_ssh_target("ts.example")[0]
-        assert not validate_url_target("http://ts.example/x")[0]
-        assert not validate_app_server_target("http://ts.example/x")[0]
+        assert validate_ssh_target("ts.example")[0], "host digitato dall'utente"
+        assert validate_app_server_target("http://ts.example/x")[0], "baseUrl dichiarato"
+        assert not validate_url_target("http://ts.example/x")[0], "target scelto dal modello"
 
 
 def test_ssrf_whitelist_applies_identically_to_both_policies():

--- a/tests/webui/test_spa_csp_header.py
+++ b/tests/webui/test_spa_csp_header.py
@@ -1,0 +1,118 @@
+"""La CSP della shell SPA — nessun test la guardava, e si e' visto.
+
+Questo header e' enforcing da luglio 2026 e non era asserito da nessuna parte
+(l'unica CSP sotto test era quella della route media, che e' un'altra:
+``default-src 'none'``). Il costo, misurato sul device il 01/09/2026: la vista
+esterna di una Jenny App e' servita dal proxy su loopback su una porta effimera,
+cioe' **un'altra origine**; senza ``frame-src`` la direttiva ricadeva su
+``default-src 'self'`` e la shell bloccava il proprio iframe con
+``net::ERR_BLOCKED_BY_CSP``. Un header di sicurezza non asserito e' un header
+che cambia comportamento senza che niente lo dica.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from jenny.webui.ws_http import GatewayHTTPHandler
+
+_AUTH_SECRET = "test-secret"
+
+
+def _make_handler(tmp_path: Path) -> GatewayHTTPHandler:
+    handler = GatewayHTTPHandler(
+        config=SimpleNamespace(
+            workspace=SimpleNamespace(enabled=True),
+            wiki=SimpleNamespace(enabled=True, wikis_dir="wikis"),
+            token_issue_secret=_AUTH_SECRET,
+            verbose=False,
+        ),
+        session_manager=None,
+        runtime_model_name=lambda: "test-model",
+        bus=MagicMock(),
+        media=MagicMock(),
+        workspaces=MagicMock(),
+        skills_workspace_path=tmp_path / "skills",
+    )
+    ui_dir = (tmp_path / "ui").resolve()
+    ui_dir.mkdir(parents=True, exist_ok=True)
+    handler.static_dist_path = ui_dir
+    return handler
+
+
+def _csp(tmp_path: Path) -> str:
+    resp = _make_handler(tmp_path)._serve_static("/html-mobile/index.html")
+    assert resp is not None and resp.status_code == 200
+    return resp.headers.get("content-security-policy", "")
+
+
+def test_index_html_carries_a_csp(tmp_path):
+    assert _csp(tmp_path), "la shell deve essere servita con una CSP"
+
+
+@pytest.mark.parametrize("directive", [
+    "default-src 'self'",
+    "script-src 'self'",
+    "connect-src 'self' ws: wss:",
+    "object-src 'none'",
+    "base-uri 'none'",
+])
+def test_the_directives_that_matter_are_intact(tmp_path, directive):
+    """Il perimetro che regge contro un'iniezione nella SPA.
+
+    ``frame-src`` sotto allarga cosa si puo' incorniciare; queste no, e allargare
+    una di queste per far funzionare una vista sarebbe la scorciatoia sbagliata.
+    """
+    assert directive in _csp(tmp_path)
+
+
+def test_frame_src_allows_the_loopback_view_proxy(tmp_path):
+    """La porta e' effimera, quindi il jolly e' sulla porta e su nient'altro."""
+    csp = _csp(tmp_path)
+    assert "frame-src 'self' http://127.0.0.1:*" in csp
+
+
+def test_frame_src_does_not_open_the_whole_web(tmp_path):
+    """Il permesso deve restare loopback: non `*`, non http: nudo, non https:.
+
+    Un `frame-src *` avrebbe fatto funzionare la vista esterna allo stesso modo,
+    ed e' esattamente l'errore che questo test esiste per fermare.
+    """
+    csp = _csp(tmp_path)
+    frame_src = next(
+        (d.strip() for d in csp.split(";") if d.strip().startswith("frame-src")), ""
+    )
+    assert frame_src, "frame-src deve essere dichiarata, non lasciata a default-src"
+    # Per TOKEN, non per sottostringa: `http:` e' contenuto in
+    # `http://127.0.0.1:*`, e un controllo a sottostringa bocciava il valore
+    # giusto (preso in pieno la prima volta che ho scritto questo test).
+    sources = frame_src.split()[1:]
+    for wide in ("*", "http:", "https:", "data:", "'unsafe-inline'"):
+        assert wide not in sources, f"frame-src non deve concedere {wide!r}"
+    for src in sources:
+        assert src == "'self'" or src.startswith("http://127.0.0.1"), (
+            f"frame-src concede un'origine non-loopback: {src!r}"
+        )
+
+
+def test_only_index_html_gets_the_csp(tmp_path):
+    """E' una policy di pagina: gli asset non ne hanno bisogno.
+
+    Metterla anche sugli asset non e' innocuo — `default-src 'self'` su un JS
+    servito a un iframe a origine opaca romperebbe i suoi stessi fetch.
+    """
+    handler = _make_handler(tmp_path)
+    # L'asset deve esistere su disco: per un path sconosciuto la shell fa da
+    # fallback e servirebbe index.html — cioe' il test misurerebbe index.html
+    # e passerebbe/fallirebbe per il motivo sbagliato (succede: verificato).
+    assets = handler.static_dist_path / "assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    (assets / "probe.css").write_text("body{}", encoding="utf-8")
+    resp = handler._serve_static("/html-mobile/assets/probe.css")
+    assert resp is not None and resp.status_code == 200
+    assert b"<!doctype" not in resp.body[:64].lower(), "e' il fallback su index.html"
+    assert "content-security-policy" not in {k.lower() for k in resp.headers.keys()}

--- a/tests/webui/test_webui_apps_routes.py
+++ b/tests/webui/test_webui_apps_routes.py
@@ -272,3 +272,129 @@ class TestAppsGateFailsClosed:
 
         assert response.status_code == 503
         assert b"disabled" in response.body
+
+
+VIEW_MANIFEST = {
+    "name": "Telecomando",
+    "description": "Il telecomando di hps",
+    "icon": "ti-device-tv",
+    "server": {"baseUrl": "http://hps:8091"},
+    "view": {"kind": "external"},
+}
+
+
+def _add_view_app(workspace: Path, slug: str = "telecomando", manifest=VIEW_MANIFEST) -> None:
+    """Una app a vista esterna: nessun app/index.html, e' il punto."""
+    app_dir = workspace / "apps" / slug
+    app_dir.mkdir(parents=True, exist_ok=True)
+    (app_dir / "app.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+class TestExternalView:
+    """La route che apre il proxy su loopback per una vista esterna.
+
+    Il proxy vero e proprio ha i suoi test in ``tests/apps/test_proxy.py``; qui
+    si guarda solo il contratto della route e il ciclo di vita del listener.
+    """
+
+    async def test_view_returns_a_loopback_url(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        workspace = _make_workspace(tmp_path)
+        _add_view_app(workspace)
+        with patch.object(handler, "_get_workspace_root", return_value=workspace), \
+             patch("jenny.apps.proxy.validate_app_server_target", return_value=(True, "")):
+            response = await handler.apps_routes._view(
+                _make_request("/api/webui/apps/telecomando/view"), "telecomando")
+            try:
+                assert response.status_code == 200
+                url = _body(response)["url"]
+                # L'URL deve stare su loopback: e' l'intero motivo del proxy —
+                # la policy cleartext dell'APK permette solo questo.
+                assert url.startswith("http://127.0.0.1:")
+                # ...e portare la capability nel path della prima navigazione.
+                assert url.rstrip("/").rsplit("/", 1)[-1]
+            finally:
+                await handler.apps_routes._view_close(
+                    _make_request("/api/webui/apps/telecomando/view/close"), "telecomando")
+
+    async def test_reopening_reuses_the_same_listener(self, tmp_path):
+        """Riaprire non deve lasciare un listener per apertura."""
+        handler = _make_handler(tmp_path)
+        workspace = _make_workspace(tmp_path)
+        _add_view_app(workspace)
+        with patch.object(handler, "_get_workspace_root", return_value=workspace), \
+             patch("jenny.apps.proxy.validate_app_server_target", return_value=(True, "")):
+            try:
+                first = _body(await handler.apps_routes._view(
+                    _make_request("/api/webui/apps/telecomando/view"), "telecomando"))["url"]
+                second = _body(await handler.apps_routes._view(
+                    _make_request("/api/webui/apps/telecomando/view"), "telecomando"))["url"]
+                assert first == second
+                assert len(handler.apps_routes._view_proxies) == 1
+            finally:
+                await handler.apps_routes._view_close(
+                    _make_request("/api/webui/apps/telecomando/view/close"), "telecomando")
+
+    async def test_close_drops_the_proxy(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        workspace = _make_workspace(tmp_path)
+        _add_view_app(workspace)
+        with patch.object(handler, "_get_workspace_root", return_value=workspace), \
+             patch("jenny.apps.proxy.validate_app_server_target", return_value=(True, "")):
+            await handler.apps_routes._view(
+                _make_request("/api/webui/apps/telecomando/view"), "telecomando")
+            assert handler.apps_routes._view_proxies
+            response = await handler.apps_routes._view_close(
+                _make_request("/api/webui/apps/telecomando/view/close"), "telecomando")
+        assert response.status_code == 200
+        assert handler.apps_routes._view_proxies == {}
+
+    async def test_a_normal_app_has_no_external_view(self, tmp_path):
+        """`note` non dichiara `view`: la route non deve aprirle un proxy."""
+        handler = _make_handler(tmp_path)
+        workspace = _make_workspace(tmp_path)
+        with patch.object(handler, "_get_workspace_root", return_value=workspace):
+            response = await handler.apps_routes._view(
+                _make_request("/api/webui/apps/note/view"), "note")
+        assert response.status_code == 400
+        assert handler.apps_routes._view_proxies == {}
+
+    async def test_blocked_target_is_refused_not_bound(self, tmp_path):
+        """Il cancello SSRF vero: nessun listener per un target rifiutato."""
+        handler = _make_handler(tmp_path)
+        workspace = _make_workspace(tmp_path)
+        _add_view_app(workspace, "loop", {
+            **VIEW_MANIFEST, "server": {"baseUrl": "http://127.0.0.1:9"},
+        })
+        with patch.object(handler, "_get_workspace_root", return_value=workspace):
+            response = await handler.apps_routes._view(
+                _make_request("/api/webui/apps/loop/view"), "loop")
+        assert response.status_code == 403
+        assert b"blocked server target" in response.body
+        assert handler.apps_routes._view_proxies == {}
+
+    async def test_view_requires_a_token(self, tmp_path):
+        handler = _make_handler(tmp_path)
+        response = await handler.apps_routes._view(
+            _make_request("/api/webui/apps/telecomando/view", token=None), "telecomando")
+        assert response.status_code == 401
+
+    async def test_view_is_routed_by_dispatch(self, tmp_path):
+        """Le due route devono essere raggiungibili, non solo esistere."""
+        handler = _make_handler(tmp_path)
+        workspace = _make_workspace(tmp_path)
+        _add_view_app(workspace)
+        with patch.object(handler, "_get_workspace_root", return_value=workspace), \
+             patch("jenny.apps.proxy.validate_app_server_target", return_value=(True, "")):
+            try:
+                opened = await handler.apps_routes.dispatch(
+                    _make_request("/api/webui/apps/telecomando/view"),
+                    "/api/webui/apps/telecomando/view")
+                assert opened is not None and opened.status_code == 200
+                closed = await handler.apps_routes.dispatch(
+                    _make_request("/api/webui/apps/telecomando/view/close"),
+                    "/api/webui/apps/telecomando/view/close")
+                assert closed is not None and closed.status_code == 200
+            finally:
+                await handler.apps_routes._view_close(
+                    _make_request("/api/webui/apps/telecomando/view/close"), "telecomando")


### PR DESCRIPTION
Two commits. The starting point was one measured symptom: an app asked to frame `http://<server>:8091` shipped looking finished and did nothing — valid to the API, page served 200, blank panel. The cause was the APK's own cleartext policy (`net::ERR_CLEARTEXT_NOT_PERMITTED`, six times in logcat, once per open; **not** Tailscale — the error fired 3 s after the tunnel came up).

That block had been hiding four independent defects.

## Four silent defects

1. **Provider errors could arrive empty.** Six sites wrote `f"...: {e}"`, and the whole httpx timeout family has `str(e) == ""` — so the user read `Error calling LLM: ` and nothing else, and so did the log. On a phone that family is the *normal* case. New `describe_exc()` falls back to the class name.
2. **`server.auth` was documented, instructed, and fatal.** `execute_http_action` is fail-closed (501), but nothing rejected the field — and app-creator's `SKILL.md` actively told authors to write `secretRef` anyway. So an app could validate clean and have every http action dead on arrival. That advice is withdrawn; `_parse_manifest` now rejects it with the remedy named, and the 501 stays as the second line.
3. **`actions` had to be non-empty**, so a display-only app was impossible — the observed result was an *invented* ping action added only to satisfy the schema. `.agent/jenny-apps.md` always said an app "can" carry an agent-facing side; the code disagreed. Now optional.
4. **A failed app page had no error surface at all.** A cross-origin iframe tells the containing JS nothing, so any failure — 404, broken script, cleartext — was a blank panel visible only in logcat, which the user does not read and the agent cannot. `MainActivity` now forwards sub-frame errors to the SPA, which shows a banner naming the host and the reason.

## Jenny Apps can now reach a Tailscale server, on both legs

- **Actions:** CGNAT (100.64.0.0/10) leaves `_APP_SERVER_BLOCKED_NETWORKS`. Its stated justification — "so an app manifest cannot use the proxy as an authenticated bridge to the gateway's own API" — was the argument for blocking *loopback*, which still is. The criterion is who names the target: the user in Settings or in a manifest gets it, the model does not.
- **Screen:** new `view: {"kind": "external"}` plus `apps/proxy.py`, a loopback listener forwarding to `server.baseUrl` at byte level. Loopback is the one origin the cleartext policy permits, so this needs no APK change and no personal hostname in a public repo. It cannot be a gateway route: the `websockets` parser does not read bodies, and a path prefix would break the remote page's root-absolute URLs.

Two defects found while testing the proxy, both in `close()`: it awaited `wait_closed()` before cancelling connection handlers, which deadlocks whenever a connection is open — i.e. every time the user closes the app with the page loaded — and the idle reaper cancelled its own task. Both now covered.

## The CSP nobody was asserting

With the proxy in place the external view still loaded nothing, and the *new* error banner said why: `net::ERR_BLOCKED_BY_CSP`. The proxy listens on an ephemeral loopback port, so it is a different origin from the gateway; the shell's CSP declared no `frame-src`, that fell back to `default-src 'self'`, and **the shell blocked its own iframe.**

`frame-src 'self' http://127.0.0.1:*` — the wildcard is on the port only, because the port is not knowable when `index.html` is served. The directives that actually bound an injection in the SPA are untouched.

The header has been enforcing since July 2026 and **no test asserted it** — the only CSP under test was the media route's, a different one. That is why nothing caught this. `tests/webui/test_spa_csp_header.py` now pins the perimeter, the loopback allowance, and that `frame-src` is not widened to `*`/`http:`/`https:`.

## Verification

- `ruff check jenny/ tests/` — clean
- `npx pyright jenny/bus jenny/command jenny/runtime jenny/session` — 0 errors (blocking subset); also clean on `apps/proxy.py`, `webui/apps_routes.py`, `security/network.py`, `providers/base.py`
- `pytest -q` on **Python 3.11**, the version the device runs — 9162 passed, 8 skipped

⚠️ **Not yet exercised on the device.** The `MainActivity.kt` change and the external-view path need a release build to be tried for real; CI does not compile the APK, so the Kotlin side lands here unverified beyond "it compiles".

🤖 Generated with [Claude Code](https://claude.com/claude-code)