### PR TITLE
Give the Telegram channel a switch that shows its own state

### DIFF
--- a/docs/using/telegram.md
+++ b/docs/using/telegram.md
@@ -40,18 +40,20 @@ This protection has a sharp edge: **it applies to you too.** If you mistype the 
 
 The attempt counter is kept **in memory only** — it also resets whenever the Jenny app itself restarts, so a restart is a (side-effect) way out too, but don't count on it as a fix.
 
-## Unlink vs. Disable
+## Unlink vs. switching the channel off
 
-Two different buttons appear once you're paired, and they behave differently:
+Once you're paired the section shows a **Channel active** toggle and an **Unpair** button. They do different things, and only one of them costs you the pairing:
 
-| Action | What it does | To reconnect |
+| Action | What it does | To get back |
 |---|---|---|
-| **Unpair** | Clears the paired chat and generates a fresh pairing code. Keeps the channel enabled. | Send the new code to the bot again — no need to touch the token. |
-| **Disable** | Stops the channel entirely (no more polling, the bot won't reply to anything) but keeps the token and the pairing on record. | You have to go through **Connect** again and re-enter the full bot token — there is no separate "re-enable" button, and the saved token is only ever shown as a masked hint, so keep the real token somewhere if you plan to re-enable later. |
+| **Channel active** (off) | Stops the channel entirely: no more polling, and the bot replies to nothing. Nothing is deleted — the token, the paired chat and its username all stay on record. | Switch the same toggle back on. That is the whole recovery: no new token, no new pairing code, no trip to BotFather. |
+| **Unpair** | Clears the paired chat and generates a fresh pairing code. Leaves the channel switched on. | Send the new code to the bot again — no need to touch the token. |
+
+The toggle is also the channel's status, not just a command: if it is off, the section says so plainly. That matters because the two states are otherwise indistinguishable from the outside — a channel that is off looks exactly like a bot that has stopped answering.
 
 ## Everything hot-reloads
 
-Saving a token, unpairing, and disabling all take effect immediately — the running channel is stopped and, if still enabled, restarted with the new configuration in the background. You never need to restart the app for a Telegram setting to take effect.
+Saving a token, unpairing, and flipping the toggle all take effect immediately — the running channel is stopped and, if still switched on, restarted with the new configuration in the background. You never need to restart the app for a Telegram setting to take effect.
 
 ## Battery exemption
 

--- a/jenny/templates/ui/assets/i18n/en.json
+++ b/jenny/templates/ui/assets/i18n/en.json
@@ -441,6 +441,7 @@
       "oemOpenFailed": "No battery management screen could be reached on this phone."
     },
     "telegram": {
+      "enable": "Channel active",
       "title": "Telegram",
       "intro": "Connect a Telegram bot to talk to Jenny from any device: the phone stays the server.",
       "step1": "Open @BotFather on Telegram and send /newbot",
@@ -458,10 +459,13 @@
       "paired": "Paired with {who}",
       "aChat": "a chat",
       "unpair": "Unpair",
-      "disable": "Disable",
       "disabled": "Telegram channel disabled",
       "batteryHint": "For instant replies even when the phone is not charging, exempt Jenny from battery optimization.",
-      "batteryButton": "Exempt from battery"
+      "batteryButton": "Exempt from battery",
+      "enabled": "Telegram channel enabled",
+      "disabledTitle": "Channel disabled",
+      "disabledPaired": "The bot does not reply. The token and the link to {who} are kept: switch it back on and it resumes where it was, with no new pairing.",
+      "disabledUnpaired": "The bot does not reply. The token is kept: switching it back on does not need another trip to BotFather."
     }
   },
   "common": {

--- a/jenny/templates/ui/assets/i18n/it.json
+++ b/jenny/templates/ui/assets/i18n/it.json
@@ -441,6 +441,7 @@
       "oemOpenFailed": "Nessuna schermata di gestione batteria raggiungibile su questo telefono."
     },
     "telegram": {
+      "enable": "Canale attivo",
       "title": "Telegram",
       "intro": "Collega un bot Telegram per parlare con Jenny da qualsiasi dispositivo: il telefono resta il server.",
       "step1": "Apri @BotFather su Telegram e invia /newbot",
@@ -458,10 +459,13 @@
       "paired": "Collegato a {who}",
       "aChat": "una chat",
       "unpair": "Scollega",
-      "disable": "Disattiva",
       "disabled": "Canale Telegram disattivato",
       "batteryHint": "Per risposte immediate anche a telefono non in carica, esenta Jenny dall'ottimizzazione batteria.",
-      "batteryButton": "Esenta dalla batteria"
+      "batteryButton": "Esenta dalla batteria",
+      "enabled": "Canale Telegram attivato",
+      "disabledTitle": "Canale disattivato",
+      "disabledPaired": "Il bot non risponde. Token e collegamento a {who} sono conservati: riaccendendo riprende da dove era, senza rifare il pairing.",
+      "disabledUnpaired": "Il bot non risponde. Il token è conservato: riaccendendo non serve ripassare da BotFather."
     }
   },
   "common": {

--- a/jenny/templates/ui/assets/mobile-style.css
+++ b/jenny/templates/ui/assets/mobile-style.css
@@ -6962,4 +6962,11 @@ body {
   padding: 12px; font-weight: 600;
 }
 .tg-paired .ti-circle-check { color: var(--accent); font-size: 20px; }
+/* Stessa forma della riga «Collegato», colore spento: è lo stato in cui il bot
+   non risponde, e deve leggersi come tale senza sembrare un errore. */
+.tg-disabled {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px; font-weight: 600; color: var(--text-faint);
+}
+.tg-disabled .ti-circle-off { font-size: 20px; }
 .tg-bot-link { color: var(--accent); font-weight: 600; }

--- a/jenny/templates/ui/assets/shared/api-client.js
+++ b/jenny/templates/ui/assets/shared/api-client.js
@@ -540,8 +540,13 @@ class ApiClient {
     return this._telegramGet('/api/telegram/unpair');
   }
 
-  async disableTelegram() {
-    return this._telegramGet('/api/telegram/disable');
+  /* Un solo metodo per i due versi del toggle. Il valore va scritto esplicito
+     (`true`/`false`) e non omesso per dire "falso": `_postWithQuery` scarta le
+     stringhe vuote, e qui l'assenza del parametro significherebbe "spegni" per
+     via del `parse_flag` lato server — comodo per sbaglio, illeggibile a
+     rileggerlo. */
+  async setTelegramEnabled(enabled) {
+    return this._telegramGet(`/api/telegram/update?enabled=${enabled ? 'true' : 'false'}`);
   }
 
   // ── Backup APIs ──

--- a/jenny/templates/ui/assets/shared/telegram-pairing.js
+++ b/jenny/templates/ui/assets/shared/telegram-pairing.js
@@ -55,12 +55,19 @@ export class TelegramPairingWidget {
     this.render();
   }
 
+  /* L'ordine dei rami è la correzione, non un dettaglio: `paired` stava per
+     primo e `enabled` non veniva letto in quel ramo, quindi un canale spento ma
+     accoppiato mostrava «✓ Collegato» — lo stato in cui il telefono è rimasto
+     dal 29/08 al 02/09 senza che niente lo dicesse. Uno stato spento non ha
+     alcuna rappresentazione se non si guarda `enabled` prima di tutto il resto. */
   render() {
     if (this._destroyed) return;
     this._stopPolling();
     const s = this.status;
     if (!s) return;
-    if (s.paired) {
+    if (s.configured && !s.enabled) {
+      this._renderDisabled();
+    } else if (s.paired) {
       this._renderPaired();
     } else if (s.enabled && s.configured && s.pairing_code) {
       this._renderPairing();
@@ -68,6 +75,25 @@ export class TelegramPairingWidget {
     } else {
       this._renderTokenForm();
     }
+  }
+
+  /* La riga del toggle, sullo stampo di `_renderSshBlock` in mobile-settings.js:
+     stesso markup e stesse classi, così le sezioni delle impostazioni si
+     somigliano invece di avere ognuna il suo interruttore. */
+  _toggleRowHtml(checked) {
+    return `
+      <div class="settings-field settings-toggle-row">
+        <label class="settings-label">${i18n.t('settings.telegram.enable')}</label>
+        <label class="toggle-switch">
+          <input type="checkbox" id="tg-enabled-toggle" ${checked ? 'checked' : ''}>
+          <span class="toggle-slider"></span>
+        </label>
+      </div>`;
+  }
+
+  _wireToggle() {
+    const el = this.el.querySelector('#tg-enabled-toggle');
+    if (el) el.addEventListener('change', () => this._setEnabled(el.checked));
   }
 
   // ── Stato: non configurato ──────────────────────────────────────────
@@ -138,7 +164,12 @@ export class TelegramPairingWidget {
       </div>`;
     this.el.querySelector('#tg-change-token').addEventListener('click', () => {
       this._stopPolling();
-      this.status = { ...this.status, configured: true, enabled: false, pairing_code: null };
+      /* Si azzera **solo** `pairing_code`, che è quanto basta a far cadere
+         `render()` sul form del token. Prima qui si scriveva anche
+         `enabled: false`, una bugia locale sullo stato del server che era
+         innocua finché nessun ramo guardava `enabled`: ora ci sarebbe la card
+         del canale spento, per un canale che è accesissimo. */
+      this.status = { ...this.status, configured: true, pairing_code: null };
       this._renderTokenForm();
     });
   }
@@ -176,27 +207,51 @@ export class TelegramPairingWidget {
     const s = this.status;
     const who = s.paired_username ? `@${escapeHtml(s.paired_username)}` : i18n.t('settings.telegram.aChat');
     const bot = s.bot_username ? ` (@${escapeHtml(s.bot_username)})` : '';
-    const settingsButtons = this.mode === 'settings' ? `
-      <div class="onboarding-nav">
-        <button class="onboarding-btn onboarding-btn-secondary" id="tg-unpair">
-          ${i18n.t('settings.telegram.unpair')}
-        </button>
-        <button class="onboarding-btn onboarding-btn-secondary" id="tg-disable">
-          ${i18n.t('settings.telegram.disable')}
-        </button>
-      </div>` : '';
+    /* Un solo bottone, e il toggle sopra. Prima erano due bottoni identici
+       affiancati — «Scollega» e «Disattiva», stessa classe, nessuna conferma —
+       ed è così che il canale è stato spento per sbaglio: su un telefono in mano
+       la distanza fra i due è un pollice. Il toggle sta in una riga sua, dice lo
+       stato invece di un'azione, e se lo sfiori si ri-tocca per rimediare
+       invece di dover rifare il pairing. */
     this.el.innerHTML = `
+      ${this.mode === 'settings' ? this._toggleRowHtml(true) : ''}
       <div class="tg-paired">
         <i class="ti ti-circle-check"></i>
         ${i18n.t('settings.telegram.paired', { who })}${bot}
       </div>
       ${this._batteryHtml()}
-      ${settingsButtons}`;
+      ${this.mode === 'settings' ? `
+      <div class="onboarding-nav">
+        <button class="onboarding-btn onboarding-btn-secondary" id="tg-unpair">
+          ${i18n.t('settings.telegram.unpair')}
+        </button>
+      </div>` : ''}`;
     const unpairBtn = this.el.querySelector('#tg-unpair');
     if (unpairBtn) unpairBtn.addEventListener('click', () => this._unpair());
-    const disableBtn = this.el.querySelector('#tg-disable');
-    if (disableBtn) disableBtn.addEventListener('click', () => this._disable());
+    this._wireToggle();
     wireBatteryExemption(this.el);
+  }
+
+  // ── Stato: configurato ma spento ────────────────────────────────────
+
+  /* Lo stato che prima non esisteva. Il toggle c'è in *entrambe* le modalità,
+     non solo in `settings`: è l'unica via d'uscita da qui, e nasconderlo
+     riprodurrebbe il vicolo cieco che questa card viene a chiudere. */
+  _renderDisabled() {
+    const s = this.status;
+    const bot = s.bot_username ? ` (@${escapeHtml(s.bot_username)})` : '';
+    const who = s.paired_username ? `@${escapeHtml(s.paired_username)}` : null;
+    const keeps = who
+      ? i18n.t('settings.telegram.disabledPaired', { who })
+      : i18n.t('settings.telegram.disabledUnpaired');
+    this.el.innerHTML = `
+      ${this._toggleRowHtml(false)}
+      <div class="tg-disabled">
+        <i class="ti ti-circle-off"></i>
+        ${i18n.t('settings.telegram.disabledTitle')}${bot}
+      </div>
+      <p class="onboarding-hint">${keeps}</p>`;
+    this._wireToggle();
   }
 
   /* Stessa card condivisa delle impostazioni e dell'onboarding, ma con il
@@ -222,15 +277,26 @@ export class TelegramPairingWidget {
     }
   }
 
-  async _disable() {
+  /* Il toggle è già visivamente girato quando arriviamo qui: il browser cambia
+     il checkbox da sé, prima di `change`. Quindi un rifiuto del server non basta
+     segnalarlo col toast — va anche rimessa a posto la levetta, altrimenti resta
+     a dichiarare uno stato che non è stato salvato. Da qui il `render()` anche
+     nel ramo d'errore, che ridisegna dallo `status` vecchio, quello vero. */
+  async _setEnabled(enabled) {
     if (this._busy) return;
     this._busy = true;
+    const el = this.el.querySelector('#tg-enabled-toggle');
+    if (el) el.disabled = true;
     try {
-      this.status = await api.disableTelegram();
-      showToast(i18n.t('settings.telegram.disabled'), 'info');
+      this.status = await api.setTelegramEnabled(enabled);
+      showToast(
+        i18n.t(enabled ? 'settings.telegram.enabled' : 'settings.telegram.disabled'),
+        'info',
+      );
       this.render();
     } catch (e) {
       showToast(e.message || i18n.t('settings.telegram.saveFailed'), 'error');
+      this.render();
     } finally {
       this._busy = false;
     }

--- a/jenny/webui/settings_routes.py
+++ b/jenny/webui/settings_routes.py
@@ -15,6 +15,7 @@ from websockets.http11 import Request as WsRequest
 from websockets.http11 import Response
 
 from jenny.bus.queue import MessageBus
+from jenny.channels.http_utils import parse_flag
 from jenny.webui.settings_api import (
     WebUISettingsError,
     delete_provider,
@@ -137,8 +138,8 @@ class WebUISettingsRouter:
             return await self._handle_telegram_save(request)
         if path == "/api/telegram/unpair":
             return await self._handle_telegram_unpair(request)
-        if path == "/api/telegram/disable":
-            return await self._handle_telegram_disable(request)
+        if path == "/api/telegram/update":
+            return await self._handle_telegram_enabled(request)
         return None
 
     def _query(self, request: WsRequest) -> QueryParams:
@@ -533,18 +534,23 @@ class WebUISettingsRouter:
         self._fire_telegram_changed()
         return self._json_response(payload)
 
-    async def _handle_telegram_disable(self, request: WsRequest) -> Response:
+    async def _handle_telegram_enabled(self, request: WsRequest) -> Response:
         if not self._authorized(request):
             return self._unauthorized()
-        from jenny.webui.telegram_api import disable_telegram
+        from jenny.webui.telegram_api import set_telegram_enabled
 
+        # ``parse_flag`` e' vero solo se il valore e' dichiarato vero, quindi un
+        # parametro assente o storto spegne. Va bene per un toggle — il client
+        # manda sempre ``true``/``false`` esplicito — ed e' il verso prudente:
+        # il caso ambiguo lascia il canale fermo, non lo accende.
+        enabled = parse_flag(_query_param(self._query(request), "enabled"))
         try:
-            payload = await disable_telegram()
+            payload = await set_telegram_enabled(enabled)
         except WebUISettingsError as e:
             return self._error_response(e.status, e.message)
         except Exception:
-            self.logger.exception("telegram disable failed")
-            return self._error_response(500, "failed to disable telegram")
+            self.logger.exception("telegram enabled toggle failed")
+            return self._error_response(500, "failed to update telegram channel")
         self._fire_telegram_changed()
         return self._json_response(payload)
 

--- a/jenny/webui/telegram_api.py
+++ b/jenny/webui/telegram_api.py
@@ -133,14 +133,37 @@ async def unpair_telegram() -> dict[str, Any]:
     return telegram_status_payload(config)
 
 
-async def disable_telegram() -> dict[str, Any]:
-    """Disabilita il canale conservando il token (riattivabile senza BotFather)."""
+async def set_telegram_enabled(enabled: bool) -> dict[str, Any]:
+    """Accende o spegne il canale conservando token e pairing.
 
-    def _apply(config: Config) -> None:
-        config.telegram.enabled = False
+    Un solo punto per i due versi, sullo stampo di ``update_ssh_settings``: il
+    campo e' un booleano, e due endpoint (``enable``/``disable``) avrebbero
+    dovuto restare d'accordo su cosa *non* toccare. Qui la risposta e' "niente
+    altro" per costruzione.
+
+    Spegnere non cancella nulla: ``bot_token``, ``paired_chat_id`` e
+    ``paired_username`` restano, quindi riaccendere non passa da BotFather ne'
+    da un nuovo pairing. E' la promessa che il vecchio ``disable_telegram``
+    faceva nel docstring senza che nessuna UI la mantenesse — non esisteva un
+    percorso che riscrivesse ``enabled = True`` senza azzerare il pairing.
+    """
+
+    def _apply(config: Config) -> bool:
+        tg = config.telegram
+        # Accendere senza token e' inerte, non un errore silenzioso da scrivere
+        # su disco: ``_init_telegram`` pretende ``enabled and bot_token``, quindi
+        # il canale non partirebbe e lo stato resterebbe a mentire.
+        if enabled and not tg.bot_token:
+            raise WebUISettingsError("telegram is not configured")
+        if tg.enabled == enabled:
+            # Niente da cambiare: il file non viene riscritto e il backup non
+            # ruota (v. ``store.mutate``).
+            return False
+        tg.enabled = enabled
+        return True
 
     config = await store.mutate(_apply)
-    logger.info("Telegram channel disabled")
+    logger.info("Telegram channel {}", "enabled" if enabled else "disabled")
     return telegram_status_payload(config)
 
 

--- a/tests/webui/test_settings_routes.py
+++ b/tests/webui/test_settings_routes.py
@@ -464,3 +464,85 @@ async def test_a_failed_write_does_not_rearm_any_job(
 
     assert response.status_code == 500
     on_jobs_changed.assert_not_called()
+
+
+# --- toggle del canale Telegram --------------------------------------------
+
+
+def _telegram_configured(config_path, *, enabled: bool) -> None:
+    """Config con token e chat accoppiata, nello stato di partenza richiesto."""
+    config = Config()
+    config.telegram.enabled = enabled
+    config.telegram.bot_token = "123456789:AAtestTOKENtestTOKENtestTOKEN"
+    config.telegram.paired_chat_id = "21824351"
+    save_config(config, config_path)
+
+
+async def test_telegram_update_requires_auth(config_path) -> None:
+    router = _router()
+    response = await router.dispatch(
+        _request("/api/telegram/update?enabled=false", token=None), "/api/telegram/update"
+    )
+    assert response.status_code == 401
+
+
+async def test_telegram_update_off_then_on_round_trips(config_path) -> None:
+    """Il giro completo che prima era una porta a senso unico.
+
+    Lo spegnimento e la riaccensione passano dalla *stessa* rotta, e in mezzo il
+    pairing non si muove: e' il punto di tutto il lavoro.
+    """
+    _telegram_configured(config_path, enabled=True)
+    router = _router(on_telegram_changed=MagicMock())
+
+    off = await router.dispatch(
+        _request("/api/telegram/update?enabled=false"), "/api/telegram/update"
+    )
+    assert off.status_code == 200
+    assert _json(off)["enabled"] is False
+    assert load_config().telegram.enabled is False
+
+    on = await router.dispatch(
+        _request("/api/telegram/update?enabled=true"), "/api/telegram/update"
+    )
+    assert on.status_code == 200
+    assert _json(on)["enabled"] is True
+    config = load_config()
+    assert config.telegram.enabled is True
+    assert config.telegram.paired_chat_id == "21824351"
+
+
+async def test_telegram_update_fires_reload(config_path) -> None:
+    """Senza questo il toggle scrive il file e il canale resta come stava."""
+    _telegram_configured(config_path, enabled=True)
+    on_changed = MagicMock()
+    router = _router(on_telegram_changed=on_changed)
+    response = await router.dispatch(
+        _request("/api/telegram/update?enabled=false"), "/api/telegram/update"
+    )
+    assert response.status_code == 200
+    on_changed.assert_called_once()
+
+
+async def test_telegram_update_enable_without_token_maps_to_400(config_path) -> None:
+    router = _router(on_telegram_changed=MagicMock())
+    response = await router.dispatch(
+        _request("/api/telegram/update?enabled=true"), "/api/telegram/update"
+    )
+    assert response.status_code == 400
+    assert load_config().telegram.enabled is False
+
+
+async def test_telegram_update_missing_param_switches_off(config_path) -> None:
+    """``parse_flag`` e' vero solo se dichiarato vero: l'ambiguo spegne.
+
+    Fissa il verso prudente, cosi' una richiesta storta non accende un canale
+    che l'utente non ha chiesto.
+    """
+    _telegram_configured(config_path, enabled=True)
+    router = _router(on_telegram_changed=MagicMock())
+    response = await router.dispatch(
+        _request("/api/telegram/update"), "/api/telegram/update"
+    )
+    assert response.status_code == 200
+    assert load_config().telegram.enabled is False

--- a/tests/webui/test_telegram_settings_api.py
+++ b/tests/webui/test_telegram_settings_api.py
@@ -1,5 +1,5 @@
 """Test per ``jenny.webui.telegram_api``: masking del token, salvataggio con
-validazione getMe, unpair/disable e persistenza del pairing."""
+validazione getMe, unpair, toggle enabled e persistenza del pairing."""
 
 from __future__ import annotations
 
@@ -12,9 +12,9 @@ from jenny.config.schema import Config
 from jenny.runtime.context import get_runtime_context
 from jenny.webui.settings_api import WebUISettingsError
 from jenny.webui.telegram_api import (
-    disable_telegram,
     record_paired,
     save_telegram_token,
+    set_telegram_enabled,
     telegram_status_payload,
     unpair_telegram,
 )
@@ -184,13 +184,79 @@ async def test_unpair_without_token_raises(tmp_path, monkeypatch) -> None:
         await unpair_telegram()
 
 
-async def test_disable_keeps_token(tmp_path, monkeypatch) -> None:
-    _configure(tmp_path, monkeypatch, enabled=True, bot_token=TOKEN)
-    payload = await disable_telegram()
+async def test_disable_keeps_token_and_pairing(tmp_path, monkeypatch) -> None:
+    """Spegnere non cancella niente: e' la precondizione del riaccendere."""
+    _configure(
+        tmp_path,
+        monkeypatch,
+        enabled=True,
+        bot_token=TOKEN,
+        paired_chat_id="21824351",
+        paired_username="someone",
+    )
+    payload = await set_telegram_enabled(False)
     assert payload["enabled"] is False
+    assert payload["paired"] is True
     config = load_config()
     assert config.telegram.bot_token == TOKEN
     assert config.telegram.enabled is False
+    assert config.telegram.paired_chat_id == "21824351"
+    assert config.telegram.paired_username == "someone"
+
+
+async def test_enable_restores_channel_without_touching_pairing(
+    tmp_path, monkeypatch
+) -> None:
+    """Il percorso che prima non esisteva.
+
+    Lo stato di partenza e' quello misurato sul telefono il 02/09/2026: spento,
+    ma con token e chat accoppiata ancora a posto. Riaccendere deve bastare —
+    senza rigenerare un ``pairing_code``, che costringerebbe a rifare il pairing
+    proprio come faceva l'unico percorso disponibile prima (``save_token``).
+    """
+    _configure(
+        tmp_path,
+        monkeypatch,
+        enabled=False,
+        bot_token=TOKEN,
+        paired_chat_id="21824351",
+        paired_username="someone",
+    )
+    payload = await set_telegram_enabled(True)
+    assert payload["enabled"] is True
+    assert payload["paired"] is True
+    assert payload["pairing_code"] is None
+    config = load_config()
+    assert config.telegram.enabled is True
+    assert config.telegram.paired_chat_id == "21824351"
+    assert config.telegram.pairing_code is None
+
+
+async def test_enable_without_token_is_refused(tmp_path, monkeypatch) -> None:
+    """``_init_telegram`` pretende ``enabled and bot_token``.
+
+    Accendere senza token darebbe uno stato che dichiara un canale acceso mentre
+    non ne parte nessuno — lo stesso genere di bugia che questo lavoro chiude.
+    """
+    _configure(tmp_path, monkeypatch)
+    with pytest.raises(WebUISettingsError, match="not configured"):
+        await set_telegram_enabled(True)
+    assert load_config().telegram.enabled is False
+
+
+async def test_toggle_to_same_value_does_not_rewrite_config(
+    tmp_path, monkeypatch
+) -> None:
+    """Un no-op non deve toccare il file ne' ruotare il backup.
+
+    Vale per il doppio tap e per una UI con lo stato vecchio in mano.
+    """
+    _configure(tmp_path, monkeypatch, enabled=True, bot_token=TOKEN)
+    config_path = tmp_path / "config.json"
+    before = config_path.stat().st_mtime_ns
+    payload = await set_telegram_enabled(True)
+    assert payload["enabled"] is True
+    assert config_path.stat().st_mtime_ns == before
 
 
 # --- concorrenza col resto delle impostazioni ------------------------------


### PR DESCRIPTION
## What went wrong

Measured on the phone on 2026-09-02, after "I sent messages and got no reply": `telegram.enabled` was `false`, so `_init_telegram` returned early, no channel was ever built, and the messages sat unread on Telegram's servers.

The snapshot store dated the flip to a four-hour window on 29/08 and showed it was the **only** change in the whole config file — the signature of `disable_telegram()`, whose single caller is the "Disattiva" button. Four and a half days of silence.

Three things made it that expensive. This PR closes all three.

## The status card lied

`render()` tested `paired` first and never read `enabled` in that branch, so a channel that was off but still paired rendered **"✓ Collegato con @…"**. Anyone checking Settings was told it was fine.

A disabled state had no representation at all — which is why there was no place a correct label could even have been chosen. The missing state, not the wrong word, was the defect.

## There was no way back

No endpoint wrote `enabled = True` except `save_telegram_token`, which clears the pairing and regenerates the code — and the saved token is only ever shown as a masked hint, so re-enabling meant a trip back to BotFather. `disable_telegram`'s docstring promised "riattivabile senza BotFather" and `docs/using/telegram.md` documented the dead end as intentional.

`set_telegram_enabled(bool)` now handles both directions and touches nothing else: token, `paired_chat_id` and `paired_username` all survive, so the recovery is flipping the switch back.

## The two buttons were a trap

"Scollega" and "Disattiva" sat adjacent with identical styling and no confirmation; on a phone in one hand the distance between them is a thumb. The toggle replaces the destructive one, sits in its own row on the model of `_renderSshBlock`, and reads as **state** rather than as an action — a mis-tap is undone by touching it again instead of by rebuilding the pairing.

## Two smaller things found on the way

- The "Cambia token" path faked `enabled: false` in the local status to force the token form. Harmless while nothing read `enabled`; with the branch order fixed it would have shown the disabled card for a running channel. It now clears only `pairing_code`, which is what actually routes `render()`.
- A toggle is already visually flipped when `change` fires, so a server refusal needs `render()` and not just a toast, or the switch keeps advertising a state that was never saved.

## Shape of the endpoint

One endpoint takes a boolean (`/api/telegram/update?enabled=…`) rather than an `enable` next to a `disable`, on the model of `update_ssh_settings`: two of them would have had to stay in agreement about what *not* to touch.

- Setting the same value twice returns `False` from the mutate callback, so a double tap does not rewrite the file or rotate the backup.
- Enabling with no token is refused — it would leave the config claiming a channel that `_init_telegram` will not start.
- `parse_flag` is true only when explicitly true, so a malformed request switches **off**: the ambiguous case leaves the channel stopped rather than starting one nobody asked for.

## Verification

- `ruff check jenny/ tests/` — clean; `npx pyright` — 0 errors on the blocking subset and on the touched modules
- `pytest -q` on **Python 3.11**, the version the device runs — 9198 passed, 8 skipped (8 new tests: the off→on round trip that keeps the pairing, the refusal to enable with no token, the no-op that does not rewrite the file)
- **Tried on the device**, release build installed over the existing signed app (`CN=flagDiZero` via `apksigner`). The live gateway serves the new asset — `tg-enabled-toggle` present, `id="tg-disable"` gone — checked by fetching it from the running process, not by listing APK entries (the WebUI lives inside `assets/chaquopy/app.imy`, so entry listings give a confident false negative). Route probe without a token: `/api/telegram/update` → 401 (registered, and the handler bailed before writing), `/api/telegram/disable` → 404.

## Still open

The channel starts with `_offset = None`, so a cold start replays whatever backlog Telegram still holds (~24 h). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)