### PR TITLE
Stop a restarted Telegram channel from replaying a stale queue, and say when it is off

### DIFF
--- a/docs/using/telegram.md
+++ b/docs/using/telegram.md
@@ -51,6 +51,8 @@ Once you're paired the section shows a **Channel active** toggle and an **Unpair
 
 The toggle is also the channel's status, not just a command: if it is off, the section says so plainly. That matters because the two states are otherwise indistinguishable from the outside — a channel that is off looks exactly like a bot that has stopped answering.
 
+Switching it back on does **not** make Jenny answer everything you sent while it was off. Telegram holds undelivered messages for about a day, and a channel that has just started ignores anything older than five minutes rather than replying to a pile of stale messages at once. The five-minute window is there so the opposite case still works: if the app restarts — Doze, an update, the watchdog — a message you sent seconds earlier is still picked up when it comes back.
+
 ## Everything hot-reloads
 
 Saving a token, unpairing, and flipping the toggle all take effect immediately — the running channel is stopped and, if still switched on, restarted with the new configuration in the background. You never need to restart the app for a Telegram setting to take effect.

--- a/jenny/channels/dispatcher.py
+++ b/jenny/channels/dispatcher.py
@@ -108,9 +108,23 @@ class WebSocketDispatcher:
         logger.info("WebSocket channel enabled")
 
     def _init_telegram(self) -> None:
-        """Crea il canale Telegram se abilitato in config con un token."""
+        """Crea il canale Telegram se abilitato in config con un token.
+
+        I due casi di uscita si loggano, e separatamente, come fa
+        ``_init_channel`` tre righe sopra per il websocket. Prima si usciva in
+        silenzio, e il costo si e' visto il 02/09/2026: un canale spento e un
+        bot che tace sono indistinguibili dall'esterno, e nei log non c'era una
+        riga che dicesse quale dei due fosse — la diagnosi e' finita a datare
+        l'``enabled`` dagli snapshot del workspace. "Spento" e "non
+        configurato" restano distinti perche' portano a due rimedi diversi: il
+        toggle nelle impostazioni, oppure il token da BotFather.
+        """
         section = self.config.telegram
-        if not (section.enabled and section.bot_token):
+        if not section.bot_token:
+            logger.info("Telegram channel not configured (no bot token)")
+            return
+        if not section.enabled:
+            logger.info("Telegram channel disabled via config (telegram.enabled=false)")
             return
         from jenny.channels.telegram import TelegramChannel
         from jenny.webui.telegram_api import record_paired

--- a/jenny/channels/telegram.py
+++ b/jenny/channels/telegram.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
@@ -35,6 +36,21 @@ from jenny.webui.metadata import WEBUI_TURN_METADATA_KEY
 _RAW_CHUNK_LIMIT = 3500
 _POLL_BACKOFF_MAX_S = 60.0
 _CHUNK_RETRY_DELAYS = (1, 2, 4)
+
+# Eta' oltre la quale un messaggio trovato in coda all'avvio non viene lavorato.
+#
+# ``get_updates`` senza offset restituisce tutto il backlog che Telegram ancora
+# trattiene (~24h di update non confermati), e ``_offset`` riparte da ``None`` a
+# ogni costruzione del canale — cioe' a ogni avvio del gateway e a ogni toggle.
+# Senza questo filtro, riaccendere il canale dopo giorni fa aprire un turno LLM
+# per ogni messaggio in coda, tutti insieme, su roba vecchia.
+#
+# Scartare *tutto* il backlog sarebbe piu' semplice ed e' sbagliato: su Android
+# le ripartenze sono ordinarie (Doze, watchdog, un aggiornamento), e un riavvio
+# tre secondi dopo che l'utente ha scritto perderebbe quel messaggio per sempre,
+# senza che niente lo dica. Cinque minuti separano i due casi che contano: il
+# messaggio scritto a cavallo di una ripartenza passa, il backlog di giorni no.
+_BACKLOG_MAX_AGE_S = 300.0
 
 # Scadenza del wakelock che copre la lavorazione di un update ricevuto.
 # Generosa rispetto al lavoro che c'è dentro (pairing, reverse-geocoding di una
@@ -140,6 +156,13 @@ class TelegramChannel:
         self._pairing_code = config.pairing_code
         self._offset: int | None = None
         self._poll_task: asyncio.Task | None = None
+        # Vero finche' stiamo smaltendo la coda che c'era *prima* di partire.
+        # Si spegne al primo update abbastanza recente (o alla prima coda
+        # vuota), e da lì non si riaccende: il filtro sull'eta' non deve poter
+        # mangiare traffico vivo per il resto della vita del processo — se
+        # l'orologio del telefono fosse sballato, un filtro permanente
+        # scarterebbe tutto in silenzio per sempre.
+        self._draining = True
         # Tentativi di pairing per chat (in-memory: si azzera al reload del
         # canale, che rigenera comunque il codice nei percorsi che contano).
         self._pair_attempts: dict[str, int] = {}
@@ -182,10 +205,20 @@ class TelegramChannel:
             try:
                 updates = await self.api.get_updates(self._offset, self.config.poll_timeout_s)
                 backoff = 1.0
+                if self._draining and not updates:
+                    # Coda vuota: non c'era backlog, o l'abbiamo finito.
+                    self._draining = False
                 for update in updates:
                     update_id = update.get("update_id")
                     if isinstance(update_id, int):
                         self._offset = update_id + 1
+                    # L'offset e' gia' avanzato, quindi uno scarto qui e'
+                    # definitivo: al prossimo giro Telegram non lo ripropone.
+                    # Deve stare *dopo* l'avanzamento, altrimenti l'update
+                    # scartato tornerebbe a ogni poll, per sempre.
+                    if self._draining and self._is_stale_backlog(update):
+                        continue
+                    self._draining = False
                     try:
                         # Il lock si prende qui, per-update, e non attorno a
                         # ``get_updates``: vedi _TELEGRAM_WAKELOCK_TIMEOUT_S.
@@ -203,6 +236,31 @@ class TelegramChannel:
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, _POLL_BACKOFF_MAX_S)
+
+    def _is_stale_backlog(self, update: dict[str, Any]) -> bool:
+        """Vero se l'update e' troppo vecchio per essere lavorato all'avvio.
+
+        Vale solo mentre ``_draining``, cioe' sul backlog che precede la
+        partenza del canale. Lo scarto e' loggato a WARNING con l'eta': e' una
+        perdita voluta ma non silenziosa, ed e' l'unica traccia che resta se
+        l'orologio del device fosse sballato e il filtro mordesse a torto.
+        """
+        message = update.get("message")
+        date = message.get("date") if isinstance(message, dict) else None
+        if not isinstance(date, int | float):
+            # Eta' non deducibile: si lavora. Scartare e' irreversibile, quindi
+            # il caso ambiguo non lo merita — al massimo si risponde a qualcosa
+            # di vecchio, che e' il male minore rispetto a perdere un messaggio.
+            return False
+        age = time.time() - float(date)
+        if age <= _BACKLOG_MAX_AGE_S:
+            return False
+        logger.warning(
+            "Telegram: dropping backlog message from startup queue (age {:.0f}s > {:.0f}s)",
+            age,
+            _BACKLOG_MAX_AGE_S,
+        )
+        return True
 
     # ------------------------------------------------------------------ #
     # Inbound                                                            #

--- a/tests/channels/test_dispatcher_telegram_gate.py
+++ b/tests/channels/test_dispatcher_telegram_gate.py
@@ -1,0 +1,62 @@
+"""Test del gate di ``WebSocketDispatcher._init_telegram`` e di cosa logga.
+
+Il gemello di ``test_dispatcher_ws_enabled_flag.py`` per l'altro canale, con in
+piu' le due righe di log. Prima ``_init_telegram`` usciva in silenzio in
+entrambi i casi di rifiuto, e il costo si e' visto il 02/09/2026: un canale
+spento e un bot che tace sono indistinguibili dall'esterno, e nei log non c'era
+niente che dicesse quale dei due fosse.
+"""
+
+from __future__ import annotations
+
+from loguru import logger as loguru_logger
+
+from jenny.bus.queue import MessageBus
+from jenny.channels.dispatcher import WebSocketDispatcher
+from jenny.config.schema import Config
+
+TOKEN = "123456789:AAtestTOKENtestTOKENtestTOKEN"
+
+
+def _dispatch_with(**telegram: object) -> tuple[WebSocketDispatcher, str]:
+    """Costruisce il dispatcher col solo ramo Telegram, catturando i log INFO.
+
+    La sezione ``websocket`` resta vuota: ``_init_channel`` esce subito su una
+    sezione falsy, cosi' il test non tira su il gateway per parlare di Telegram.
+    """
+    config = Config.model_validate({"telegram": telegram})
+    records: list[str] = []
+    handler_id = loguru_logger.add(lambda m: records.append(str(m)), level="INFO")
+    try:
+        dispatcher = WebSocketDispatcher(config, MessageBus())
+    finally:
+        loguru_logger.remove(handler_id)
+    return dispatcher, "\n".join(records)
+
+
+def test_enabled_with_token_builds_channel() -> None:
+    dispatcher, log = _dispatch_with(enabled=True, botToken=TOKEN)
+
+    assert "telegram" in dispatcher.channels
+    assert "Telegram channel enabled" in log
+
+
+def test_disabled_skips_channel_and_says_so() -> None:
+    """Il caso misurato sul telefono: token a posto, ``enabled`` a false."""
+    dispatcher, log = _dispatch_with(enabled=False, botToken=TOKEN)
+
+    assert "telegram" not in dispatcher.channels
+    assert "telegram.enabled=false" in log
+
+
+def test_missing_token_is_reported_as_not_configured() -> None:
+    """«Spento» e «non configurato» portano a due rimedi diversi.
+
+    Il toggle nelle impostazioni oppure il token da BotFather: un log solo per
+    i due casi lascerebbe da indovinare quale.
+    """
+    dispatcher, log = _dispatch_with(enabled=True)
+
+    assert "telegram" not in dispatcher.channels
+    assert "not configured" in log
+    assert "telegram.enabled=false" not in log

--- a/tests/channels/test_telegram_backlog.py
+++ b/tests/channels/test_telegram_backlog.py
@@ -1,0 +1,149 @@
+"""Test dello smaltimento del backlog all'avvio del canale Telegram.
+
+``get_updates`` senza offset restituisce tutto cio' che Telegram trattiene, e
+``_offset`` riparte da ``None`` a ogni costruzione del canale — cioe' a ogni
+avvio del gateway e a ogni toggle. Qui si fissa il confine fra i due casi che
+contano: il messaggio scritto a cavallo di una ripartenza va lavorato, il
+backlog di giorni no.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from jenny.bus.queue import MessageBus
+from jenny.channels.telegram import _BACKLOG_MAX_AGE_S, TelegramChannel
+from jenny.config.schema import TelegramConfig
+
+CHAT = "21824351"
+
+
+def _update(update_id: int, *, age_s: float, text: str) -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "message": {
+            "chat": {"id": int(CHAT)},
+            "from": {"id": int(CHAT)},
+            "date": int(time.time() - age_s),
+            "text": text,
+        },
+    }
+
+
+class ScriptedAPI:
+    """``get_updates`` che serve batch prefissati, poi si blocca.
+
+    Il blocco finale imita il long-poll: il loop resta appeso lì invece di
+    girare a vuoto, e il test lo cancella quando ha visto quel che gli serve.
+    """
+
+    def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+        self.batches = list(batches)
+        self.offsets: list[int | None] = []
+        self.drained = asyncio.Event()
+
+    async def get_updates(self, offset, timeout_s):
+        self.offsets.append(offset)
+        if self.batches:
+            return self.batches.pop(0)
+        self.drained.set()
+        await asyncio.sleep(3600)
+
+    async def close(self) -> None:
+        return None
+
+
+async def _run(batches: list[list[dict[str, Any]]]) -> tuple[list[str], ScriptedAPI]:
+    """Fa girare il poll loop sui batch dati; ritorna i contenuti pubblicati."""
+    api = ScriptedAPI(batches)
+    bus = MessageBus()
+    channel = TelegramChannel(
+        TelegramConfig(enabled=True, bot_token="t", paired_chat_id=CHAT),
+        bus,
+        api=api,  # type: ignore[arg-type]
+    )
+    task = asyncio.create_task(channel._poll_loop())
+    await asyncio.wait_for(api.drained.wait(), timeout=5)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    published: list[str] = []
+    while not bus.inbound.empty():
+        published.append(bus.inbound.get_nowait().content)
+    return published, api
+
+
+async def test_stale_backlog_is_dropped_on_startup() -> None:
+    """Il caso che ha motivato tutto: giorni di coda, riaccensione, raffica."""
+    old = _BACKLOG_MAX_AGE_S + 3600
+    published, _ = await _run([[
+        _update(1, age_s=old, text="vecchio uno"),
+        _update(2, age_s=old, text="vecchio due"),
+    ]])
+
+    assert published == []
+
+
+async def test_message_across_a_restart_survives() -> None:
+    """Il motivo per cui non si scarta il backlog in blocco.
+
+    Su Android le ripartenze sono ordinarie: un riavvio pochi secondi dopo che
+    l'utente ha scritto non deve perdere quel messaggio.
+    """
+    published, _ = await _run([[_update(1, age_s=3, text="ciao")]])
+
+    assert published == ["ciao"]
+
+
+async def test_dropped_updates_still_advance_the_offset() -> None:
+    """Senza questo, uno scarto tornerebbe a ogni poll per sempre.
+
+    L'offset va avanzato *prima* di decidere lo scarto: e' la conferma verso
+    Telegram, e senza di essa il backlog non si smaltisce mai.
+    """
+    old = _BACKLOG_MAX_AGE_S + 3600
+    _, api = await _run([[_update(7, age_s=old, text="vecchio")]])
+
+    assert api.offsets[0] is None  # avvio a freddo: nessun offset
+    assert api.offsets[1] == 8  # 7 + 1, nonostante lo scarto
+
+
+async def test_filter_stops_after_the_first_fresh_message() -> None:
+    """Il filtro non deve poter mangiare traffico vivo a vita.
+
+    Un messaggio recente chiude lo smaltimento; da lì anche un update con una
+    data vecchia (orologio sballato, o un inoltro) viene lavorato.
+    """
+    old = _BACKLOG_MAX_AGE_S + 3600
+    published, _ = await _run([
+        [_update(1, age_s=old, text="scartato"), _update(2, age_s=1, text="recente")],
+        [_update(3, age_s=old, text="passa comunque")],
+    ])
+
+    assert published == ["recente", "passa comunque"]
+
+
+async def test_empty_first_batch_ends_draining() -> None:
+    """Coda vuota all'avvio: non c'era backlog, e il filtro si spegne subito."""
+    old = _BACKLOG_MAX_AGE_S + 3600
+    published, _ = await _run([[], [_update(1, age_s=old, text="dopo il vuoto")]])
+
+    assert published == ["dopo il vuoto"]
+
+
+async def test_update_without_a_readable_date_is_processed() -> None:
+    """Eta' non deducibile: si lavora.
+
+    Scartare e' irreversibile, quindi il caso ambiguo non lo merita.
+    """
+    published, _ = await _run([[{
+        "update_id": 1,
+        "message": {"chat": {"id": int(CHAT)}, "from": {"id": int(CHAT)}, "text": "senza data"},
+    }]])
+
+    assert published == ["senza data"]


### PR DESCRIPTION
The two loose ends left by #27, both about the same thing: a channel whose state you cannot see, and a queue you cannot see either.

## The backlog

`get_updates` with no offset returns everything Telegram still holds — roughly a day of unconfirmed updates — and `_offset` restarts from `None` on every construction of the channel, which means **every gateway start and every flip of the toggle**. Switching the channel back on after four days therefore opened an LLM turn for every queued message at once, on days-old input.

Dropping the whole backlog is simpler and it is wrong. On Android a restart is ordinary — Doze, the watchdog, an update — and a restart three seconds after the user typed would lose that message for good, with nothing to say so. Five minutes separates the two cases that matter: **a message written across a restart is handled, a queue of days is not.**

Three mechanics worth naming, because the obvious version of each is broken:

- The staleness check runs **after** `_offset` has advanced. The offset is the confirmation back to Telegram, so a drop decided before it would return on every poll, forever — the backlog would never clear.
- Draining stops at the first message recent enough (or the first empty queue) and **never resumes**. A permanent age filter would be a silent, total outage if the phone's clock were ever wrong; bounded, the worst case ends as soon as one live message gets through. Every drop is logged at WARNING with the age — the only trace left if the filter ever bites wrongly.
- An update whose date cannot be read is **handled, not dropped**. Dropping is the irreversible direction, so the ambiguous case does not get it.

## The silence

`_init_telegram` returned without a word in both of its refusal branches, and that is what turned a one-line diagnosis into archaeology through the workspace snapshots: a disabled channel and a bot that has stopped answering are indistinguishable from outside, and nothing in the log said which one this was.

It now logs both cases, and separately, like `_init_channel` does for the websocket three lines above — "disabled" and "not configured" lead to different remedies (the toggle, or a token from BotFather).

## Verification

- `ruff check jenny/ tests/` — clean; `npx pyright` — 0 errors on the touched modules
- `pytest -q` on **Python 3.11**, the version the device runs — 9207 passed, 8 skipped (9 new tests)
- **Both the filter and the ordering are verified load-bearing by mutation**, with the bytecode cache cleared between runs: neutering `_is_stale_backlog` fails two tests, and moving the offset advance after the drop decision fails the one written for it. A first mutation attempt — raising `_BACKLOG_MAX_AGE_S` — changed nothing, because the tests derive their ages from the constant instead of hard-coding a window; that is the test being right, not the mutation.

No new config knob: the window is a module constant with the tradeoff argued at the definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)