### PR TITLE
Mark the history rows the user did not write

### DIFF
--- a/.agent/gotchas.md
+++ b/.agent/gotchas.md
@@ -67,6 +67,36 @@ duration and `_save_turn` appends its block at the end, so an unlocked append ca
 between an `assistant`/`tool_calls` message and its `tool` result — an illegal request for
 the provider.
 
+## Una riga `role: "user"` non è sempre l'utente
+
+Nella storia di sessione quel ruolo è **anche** la forma con cui il sistema parla al modello,
+e tre cose lo usano senza che nessuno abbia digitato niente: un turno di cron, il rientro di
+un subagent iniettato a metà turno (`AgentLoop._drain_pending` normalizza qualunque messaggio
+in coda a `{"role": "user", ...}`) e lo sprone a un sustained goal. Il marcatore che le
+distingue, e l'elenco completo, stanno in `jenny/session/history_meta.py`:
+`is_synthetic_history_row()`.
+
+Chiunque legga la storia per rispondere a una domanda **sull'utente** deve passare da lì. I
+tre lettori di oggi: la bolla da mostrare in chat
+(`webui/transcript.py::_session_user_event`, che il backfill usa quando il transcript di
+display non ha un evento `user` per quel turno), il titolo della conversazione
+(`session/webui_turns.py::_title_inputs`) e «si è fatto vivo dopo che gli abbiamo scritto?»
+(`session/manager.py::last_user_message_ms`, da cui dipende il riarmo dell'heartbeat).
+
+Misurato sul device il 05/09/2026: solo il turno di cron era marcato. Un rientro di subagent
+finito *dentro* il turno che lo aveva lanciato veniva quindi mostrato in chat come una bolla
+dell'utente col prompt integrale del subagent dentro, e contava come «l'utente ha parlato»
+per il riarmo. Lo stesso rientro arrivato *dopo* la fine del turno passava invece da
+`_persist_subagent_followup`, che lo marcava, e non si vedeva: la visibilità dipendeva dal
+tempismo del subagent.
+
+Il marcatore vive **solo** nel JSONL. `SessionManager.get_history` ricostruisce i messaggi per
+il modello con una whitelist di chiavi e i provider ne fanno un'altra prima del filo
+(`LLMProvider._sanitize_request_messages`), quindi è lecito appenderlo a un dict che è anche
+il payload della richiesta in corso. Le due whitelist sono verificate in
+`tests/session/test_history_meta.py`: se una delle due smettesse di filtrare, il campo
+finirebbe su un endpoint che non lo conosce.
+
 ## Skills as Extension Point
 
 Built-in skills live in `jenny/skills/` (markdown + YAML frontmatter format). Agent capabilities that are "know-how" rather than code should be added as skills, not hardcoded into the agent loop. External skills can be published to and installed from ClawHub.

--- a/jenny/agent/loop.py
+++ b/jenny/agent/loop.py
@@ -78,6 +78,10 @@ from jenny.session.goal_state import (
     runner_wall_llm_timeout_s,
     sustained_goal_active,
 )
+from jenny.session.history_meta import (
+    INJECTED_EVENT_META,
+    SUBAGENT_RESULT_EVENT,
+)
 from jenny.session.keys import (
     PROJECT_SESSION_PREFIX,
     is_project_session_key,
@@ -1356,7 +1360,24 @@ class AgentLoop(StateHandlersMixin, ProviderPresetMixin, TurnPersistenceMixin, L
                     content, media = self._prepare_message_media(content, media)
                     media = media or None
                 user_content = self.context._build_user_content(content, media)
-                return {"role": "user", "content": user_content}
+                message: dict[str, Any] = {"role": "user", "content": user_content}
+                # Il ruolo `user` qui è la forma che il modello deve vedere, non
+                # un fatto sull'utente: un rientro di subagent entra da questa
+                # coda esattamente come un messaggio digitato. La metadata è
+                # l'unico posto in cui i due si distinguono ancora, e senza
+                # riportarla il dict finisce in storia indistinguibile da una
+                # riga scritta davvero (v. `jenny.session.history_meta`).
+                injected_event = (
+                    pending_msg.metadata.get(INJECTED_EVENT_META)
+                    if isinstance(pending_msg.metadata, dict)
+                    else None
+                )
+                if injected_event == SUBAGENT_RESULT_EVENT:
+                    message[INJECTED_EVENT_META] = SUBAGENT_RESULT_EVENT
+                    task_id = pending_msg.metadata.get("subagent_task_id")
+                    if task_id:
+                        message["subagent_task_id"] = task_id
+                return message
 
             items: list[dict[str, Any]] = []
             while len(items) < limit:

--- a/jenny/agent/turn_persistence.py
+++ b/jenny/agent/turn_persistence.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from jenny.agent.context import ContextBuilder
+from jenny.session.history_meta import (
+    INJECTED_EVENT_META,
+    SUBAGENT_RESULT_EVENT,
+)
 from jenny.utils.helpers import image_placeholder_text
 from jenny.utils.helpers import truncate_text as truncate_text_fn
 
@@ -154,7 +158,8 @@ class TurnPersistenceMixin:
             return False
         task_id = msg.metadata.get("subagent_task_id") if isinstance(msg.metadata, dict) else None
         if task_id and any(
-            m.get("injected_event") == "subagent_result" and m.get("subagent_task_id") == task_id
+            m.get(INJECTED_EVENT_META) == SUBAGENT_RESULT_EVENT
+            and m.get("subagent_task_id") == task_id
             for m in session.messages
         ):
             return False
@@ -162,7 +167,7 @@ class TurnPersistenceMixin:
             "assistant",
             msg.content,
             sender_id=msg.sender_id,
-            injected_event="subagent_result",
+            injected_event=SUBAGENT_RESULT_EVENT,
             subagent_task_id=task_id,
         )
         return True

--- a/jenny/session/history_meta.py
+++ b/jenny/session/history_meta.py
@@ -1,0 +1,83 @@
+"""Righe di storia che portano ``role: "user"`` senza essere parole dell'utente.
+
+Una riga ``role: "user"`` nel JSONL di sessione è l'unico segno che Jenny ha di
+«ha parlato l'utente», e **tre** cose la scrivono senza essere l'utente:
+
+- un turno di cron, che si persiste come un messaggio qualsiasi
+  (``jenny/cron/session_turns.py::cron_history_overrides``);
+- il rientro di un subagent iniettato a metà turno, che
+  ``AgentLoop._drain_pending`` normalizza a ``{"role": "user", ...}`` per darlo
+  al modello, e che finisce in storia con quel ruolo;
+- la continuazione sintetica di un sustained goal
+  (``jenny/utils/runtime.py::build_goal_continue_message``).
+
+Chi legge la storia per rispondere a una domanda **sull'utente** — quale bolla
+mostrare in chat, come titolare la conversazione, «si è fatto vivo dopo che gli
+abbiamo scritto?» — deve saltarle tutte e tre. Prima ne esisteva il marcatore
+per una sola (cron), e le altre due passavano: da qui la bolla con dentro il
+prompt di un subagent, un promemoria che si spacciava per una risposta e un
+riarmo di heartbeat davanti a uno schermo vuoto. Questo modulo è il posto unico
+dove si dice quali righe sono, così i tre lettori non divergono.
+
+Il marcatore vive **solo** nel JSONL: ``SessionManager.get_history`` ricostruisce
+i messaggi per il modello con una whitelist di chiavi, e i provider ne fanno
+un'altra prima del filo (``LLMProvider._sanitize_request_messages``). Quel che si
+scrive qui non raggiunge mai l'API.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+#: Chiave che nomina l'evento interno da cui una riga di storia è nata.
+INJECTED_EVENT_META = "injected_event"
+
+#: Rientro di un subagent. Lo scrivono entrambi i rami d'annuncio: l'iniezione
+#: a metà turno (``AgentLoop._drain_pending``) e il turno d'annuncio autonomo
+#: (``TurnPersistenceMixin._persist_subagent_followup``).
+SUBAGENT_RESULT_EVENT = "subagent_result"
+
+#: Sprone sintetico a un sustained goal ancora attivo.
+GOAL_CONTINUE_EVENT = "goal_continue"
+
+#: Ripresa dopo un output troncato dal tetto di token.
+LENGTH_RECOVERY_EVENT = "length_recovery"
+
+_INJECTED_EVENTS = frozenset({
+    SUBAGENT_RESULT_EVENT,
+    GOAL_CONTINUE_EVENT,
+    LENGTH_RECOVERY_EVENT,
+})
+
+
+def is_synthetic_history_row(message: Mapping[str, Any] | None) -> bool:
+    """True per una riga di storia che l'utente non ha scritto.
+
+    Vale anche su una riga ``role: "assistant"`` — è la forma con cui il turno
+    d'annuncio autonomo persiste lo stesso rientro di subagent — e i chiamanti
+    la vogliono saltare comunque: nessuna delle tre domande di cui sopra la
+    riguarda.
+    """
+    if not message:
+        return False
+    # Import dentro la funzione, e non in testa: ``jenny.cron.session_turns``
+    # importa ``jenny.session.keys``, che esegue ``jenny/session/__init__.py``,
+    # che carica ``manager``, che importa questo modulo — e tornerebbe su
+    # ``session_turns`` ancora a metà inizializzazione. Misurato il 2026-08-17
+    # su ``manager.py``, che portava questo stesso import in testa: a freddo
+    # ``import jenny.cron.session_turns`` sollevava, e la suite era verde perché
+    # una raccolta completa carica ``jenny.session`` per prima. La guardia che
+    # lo misura è ``tests/session/test_cold_imports.py``, che importa ogni
+    # modulo di ``jenny/`` in un interprete nuovo.
+    #
+    # L'alternativa era rendere pigro ``jenny/session/__init__.py``, e costa più
+    # di quanto sembri: una ``__getattr__`` di modulo fa diventare ``Any`` ogni
+    # attributo sconosciuto del package — misurato, ``jenny.session.SessionManagr``
+    # smette di essere un errore — e ``jenny/session`` sta nel sottoinsieme
+    # **bloccante** di pyright. Si perderebbe il controllo dei nomi su tutto il
+    # package per chiudere un ciclo che si chiude qui in una riga.
+    from jenny.cron.session_turns import CRON_HISTORY_META
+
+    if message.get(CRON_HISTORY_META) is True:
+        return True
+    return message.get(INJECTED_EVENT_META) in _INJECTED_EVENTS

--- a/jenny/session/manager.py
+++ b/jenny/session/manager.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from loguru import logger
 
+from jenny.session.history_meta import is_synthetic_history_row
 from jenny.utils.helpers import (
     channel_delivery_aware_user_start,
     ensure_dir,
@@ -318,10 +319,13 @@ def last_user_message_ms(session: Session | None) -> int | None:
       compreso il momento in cui scrive l'avviso stesso che si sta cercando di
       ricordare (``loop.py``, ``record_channel_delivery``). Serve una riga
       ``role == "user"``, non l'ultima attività della sessione.
-    - **non** i turni di cron. Un job ``reminder`` si persiste nella storia
-      esattamente come un messaggio dell'utente — stessa riga, stesso ruolo
-      (``cron_history_overrides``) — e contarlo vorrebbe dire che un promemoria
-      delle 09:00 "risponde" ogni mattina al posto di chi dorme.
+    - **non** le righe che l'utente non ha scritto pur portandone il ruolo. Un
+      job ``reminder`` si persiste nella storia esattamente come un messaggio
+      dell'utente — stessa riga, stesso ruolo (``cron_history_overrides``) — e
+      contarlo vorrebbe dire che un promemoria delle 09:00 "risponde" ogni
+      mattina al posto di chi dorme. Lo stesso vale per il rientro di un
+      subagent e per lo sprone a un sustained goal: l'elenco completo, e il
+      perché, stanno in ``jenny.session.history_meta``.
     - **non** ``timestamp`` presi per buoni: la riga potrebbe non averlo, o
       averlo illeggibile. Si scorre indietro fino alla prima utilizzabile, che
       è la direzione sicura — un timbro più vecchio riarma di meno, mai di più.
@@ -332,25 +336,8 @@ def last_user_message_ms(session: Session | None) -> int | None:
     """
     if session is None:
         return None
-    # Import dentro la funzione, e non in testa al modulo, perché altrimenti è un
-    # ciclo: ``jenny.cron.session_turns`` importa ``jenny.session.keys``, che
-    # esegue ``jenny/session/__init__.py``, che carica questo modulo, che tornerebbe
-    # su ``session_turns`` ancora a metà inizializzazione. Misurato il 2026-08-17: a
-    # freddo ``import jenny.cron.session_turns`` falliva, e la suite era verde perché
-    # una raccolta completa carica ``jenny.session`` per prima.
-    #
-    # L'alternativa era rendere pigro ``jenny/session/__init__.py``, e costa più di
-    # quanto sembri: una ``__getattr__`` di modulo fa diventare ``Any`` ogni
-    # attributo sconosciuto del package — misurato, ``jenny.session.SessionManagr``
-    # smette di essere un errore — e ``jenny/session`` sta nel sottoinsieme
-    # **bloccante** di pyright. Si perderebbe il controllo dei nomi su tutto il
-    # package per chiudere un ciclo che si chiude qui in una riga. La stringa resta
-    # importata e non ricopiata: è la chiave con cui un turno di cron si marca nella
-    # storia, e questa funzione deve saltarla.
-    from jenny.cron.session_turns import CRON_HISTORY_META
-
     for message in reversed(session.messages):
-        if message.get("role") != "user" or message.get(CRON_HISTORY_META):
+        if message.get("role") != "user" or is_synthetic_history_row(message):
             continue
         raw = message.get("timestamp")
         if not isinstance(raw, str):

--- a/jenny/session/webui_turns.py
+++ b/jenny/session/webui_turns.py
@@ -20,8 +20,8 @@ from jenny.bus.runtime_events import (
     TurnCompleted,
     TurnRunStatusChanged,
 )
-from jenny.cron.session_turns import CRON_HISTORY_META
 from jenny.providers.base import LLMProvider
+from jenny.session.history_meta import is_synthetic_history_row
 from jenny.session.keys import UNIFIED_SESSION_KEY
 from jenny.session.manager import Session, SessionManager
 from jenny.session.turn_visibility import resolve_turn_visibility
@@ -94,7 +94,9 @@ def _title_inputs(session: Session) -> tuple[str, str]:
     for message in session.messages:
         if message.get("_command") is True:
             continue
-        if message.get(CRON_HISTORY_META) is True:
+        # Un turno di cron, un rientro di subagent o uno sprone a un goal non
+        # sono di che parla la conversazione: v. ``jenny.session.history_meta``.
+        if is_synthetic_history_row(message):
             continue
         role = message.get("role")
         content = message.get("content")

--- a/jenny/utils/runtime.py
+++ b/jenny/utils/runtime.py
@@ -8,6 +8,11 @@ from typing import Any
 from loguru import logger
 
 from jenny.security.workspace_policy import _safe_expanduser
+from jenny.session.history_meta import (
+    GOAL_CONTINUE_EVENT,
+    INJECTED_EVENT_META,
+    LENGTH_RECOVERY_EVENT,
+)
 from jenny.utils.helpers import stringify_text_blocks
 
 _MAX_REPEAT_EXTERNAL_LOOKUPS = 2
@@ -107,7 +112,15 @@ def looks_like_user_question(content: str | None) -> bool:
 
 
 def build_finalization_retry_message() -> dict[str, str]:
-    """A short no-tools-allowed prompt for final answer recovery."""
+    """A short no-tools-allowed prompt for final answer recovery.
+
+    Senza marcatore ``injected_event``, a differenza di ``build_goal_continue_message``
+    e ``build_length_recovery_message``: questo prompt e quello di budget esaurito
+    finiscono in una *copia* della lista (``_finalization_retry_messages``,
+    ``_budget_exhausted_finalization_messages``) che serve solo alla richiesta e al
+    conteggio token, e non arriva mai alla storia di sessione. Marcarli direbbe il
+    falso su dove vanno a finire.
+    """
     return {"role": "user", "content": FINALIZATION_RETRY_PROMPT}
 
 
@@ -118,12 +131,20 @@ def build_budget_exhausted_finalization_message() -> dict[str, str]:
 
 def build_length_recovery_message() -> dict[str, str]:
     """Prompt the model to continue after hitting output token limit."""
-    return {"role": "user", "content": LENGTH_RECOVERY_PROMPT}
+    return {
+        "role": "user",
+        "content": LENGTH_RECOVERY_PROMPT,
+        INJECTED_EVENT_META: LENGTH_RECOVERY_EVENT,
+    }
 
 
 def build_goal_continue_message(custom: str | None = None) -> dict[str, str]:
     """Prompt the model to continue when a sustained goal is still active."""
-    return {"role": "user", "content": custom or SUSTAINED_GOAL_CONTINUE_PROMPT}
+    return {
+        "role": "user",
+        "content": custom or SUSTAINED_GOAL_CONTINUE_PROMPT,
+        INJECTED_EVENT_META: GOAL_CONTINUE_EVENT,
+    }
 
 
 def external_lookup_signature(tool_name: str, arguments: Any) -> str | None:

--- a/jenny/webui/transcript.py
+++ b/jenny/webui/transcript.py
@@ -7,7 +7,7 @@ import binascii
 import json
 from typing import Any, Callable, NamedTuple
 
-from jenny.cron.session_turns import CRON_HISTORY_META
+from jenny.session.history_meta import is_synthetic_history_row
 
 # Re-export per gli importatori esterni (media_gateway, ecc.). L'alias ridondante
 # segnala a ruff che è un re-export intenzionale (non un import inutilizzato).
@@ -349,7 +349,9 @@ def _session_user_event(
 ) -> dict[str, Any] | None:
     if message.get("role") != "user":
         return None
-    if message.get(CRON_HISTORY_META) is True:
+    # Una riga che l'utente non ha scritto non e' una bolla da mostrargli, anche
+    # se ne porta il ruolo: v. ``jenny.session.history_meta``.
+    if is_synthetic_history_row(message):
         return None
     content = message.get("content")
     text = content if isinstance(content, str) else ""

--- a/tests/agent/test_loop_save_turn.py
+++ b/tests/agent/test_loop_save_turn.py
@@ -12,6 +12,11 @@ from jenny.bus.queue import MessageBus
 from jenny.cron.session_turns import CRON_HISTORY_META, CRON_TRIGGER_META
 from jenny.providers.base import LLMResponse
 from jenny.session.goal_state import GOAL_STATE_KEY
+from jenny.session.history_meta import (
+    INJECTED_EVENT_META,
+    SUBAGENT_RESULT_EVENT,
+    is_synthetic_history_row,
+)
 from jenny.session.keys import UNIFIED_SESSION_KEY
 from jenny.session.manager import Session
 from jenny.session.turn_continuation import (
@@ -109,6 +114,68 @@ def test_persist_cron_turn_uses_distinct_history_marker(tmp_path: Path) -> None:
     assert message["cron_job_name"] == "Daily check"
     assert message["cron_run_id"] == "job-1:1"
     assert message["cron_prompt_ref"] == prompt_ref
+
+
+@pytest.mark.asyncio
+async def test_injected_subagent_result_is_marked_in_history(tmp_path: Path) -> None:
+    """L'annuncio di rientro di un subagent non si confonde con l'utente.
+
+    Il gemello di ``test_persist_cron_turn_uses_distinct_history_marker`` per
+    l'altra riga sintetica. ``AgentLoop._drain_pending`` normalizza qualunque
+    messaggio in coda a ``{"role": "user", ...}`` — è la forma che il modello
+    deve vedere — e il turno si persiste con quella forma. Senza riportare la
+    metadata, il rientro di un subagent finiva in storia indistinguibile da una
+    frase digitata: bolla in chat, titolo della conversazione, riarmo
+    dell'heartbeat (v. ``jenny.session.history_meta``).
+    """
+    loop = _make_full_loop(tmp_path)
+    loop.consolidator.maybe_consolidate_by_tokens = AsyncMock(return_value=False)  # type: ignore[method-assign]
+    loop.provider.chat_with_retry = AsyncMock(
+        side_effect=[
+            LLMResponse(content="delego al subagent", finish_reason="stop"),
+            LLMResponse(content="backup ok", finish_reason="stop"),
+        ]
+    )
+
+    pending: asyncio.Queue = asyncio.Queue()
+    pending.put_nowait(
+        InboundMessage(
+            channel="system",
+            sender_id="subagent",
+            chat_id="websocket:c-announce",
+            content="[Subagent 'backup' completed successfully]\n\nTask: leggi l'hub…",
+            metadata={
+                INJECTED_EVENT_META: SUBAGENT_RESULT_EVENT,
+                "subagent_task_id": "ff0941f9",
+            },
+        )
+    )
+
+    await loop._process_message(
+        InboundMessage(
+            channel="websocket",
+            sender_id="u1",
+            chat_id="c-announce",
+            content="com'è andato il backup?",
+        ),
+        pending_queue=pending,
+    )
+
+    session = loop.sessions.get_or_create(UNIFIED_SESSION_KEY)
+    announce = [
+        m for m in session.messages
+        if isinstance(m.get("content"), str) and m["content"].startswith("[Subagent ")
+    ]
+    assert len(announce) == 1, session.messages
+    assert announce[0]["role"] == "user"
+    assert announce[0][INJECTED_EVENT_META] == SUBAGENT_RESULT_EVENT
+    assert announce[0]["subagent_task_id"] == "ff0941f9"
+    assert is_synthetic_history_row(announce[0]) is True
+
+    # Il messaggio vero dell'utente resta quello che è.
+    typed = [m for m in session.messages if m.get("content") == "com'è andato il backup?"]
+    assert len(typed) == 1
+    assert is_synthetic_history_row(typed[0]) is False
 
 
 def test_clean_generated_title_strips_reasoning_tags() -> None:

--- a/tests/cron/test_heartbeat_user_rearm.py
+++ b/tests/cron/test_heartbeat_user_rearm.py
@@ -54,8 +54,14 @@ from jenny.cron.types import (
     CronTaskCheckState,
 )
 from jenny.runtime.cron_dispatch import CronDispatcher
+from jenny.session.history_meta import (
+    GOAL_CONTINUE_EVENT,
+    INJECTED_EVENT_META,
+    SUBAGENT_RESULT_EVENT,
+)
 from jenny.session.keys import UNIFIED_SESSION_KEY, session_key_for_channel
 from jenny.session.manager import Session, last_user_message_ms
+from jenny.utils.runtime import SUSTAINED_GOAL_CONTINUE_PROMPT
 
 _WATERBOT = (
     "- Ogni ciclo, controlla l'umidità delle piante e avvisami solo se una è sotto il 15%."
@@ -502,6 +508,45 @@ class TestTheLastUserMessageReader:
                 "content": "promemoria",
                 "timestamp": reminder.isoformat(),
                 CRON_HISTORY_META: True,
+            },
+        ]
+
+        assert last_user_message_ms(session) == int(human.timestamp() * 1000)
+
+    def test_a_subagent_announce_is_skipped_and_the_real_one_behind_it_wins(self) -> None:
+        """Un subagent che rientra non è l'utente che si presenta.
+
+        Misurato sul device il 05/09/2026: l'annuncio iniettato a metà turno si
+        persiste con ``role: "user"`` come il turno di cron qui sopra, e senza
+        marcatore riarmava ogni avviso già mandato — di notte, davanti a uno
+        schermo spento.
+        """
+        session = Session(key=UNIFIED_SESSION_KEY)
+        human = datetime(2026, 8, 16, 9, 0, 0)
+        announce = human + timedelta(hours=3)
+        session.messages = [
+            {"role": "user", "content": "a", "timestamp": human.isoformat()},
+            {
+                "role": "user",
+                "content": "[Subagent 'backup latest hps' completed successfully]…",
+                "timestamp": announce.isoformat(),
+                INJECTED_EVENT_META: SUBAGENT_RESULT_EVENT,
+            },
+        ]
+
+        assert last_user_message_ms(session) == int(human.timestamp() * 1000)
+
+    def test_a_goal_continuation_is_skipped_too(self) -> None:
+        session = Session(key=UNIFIED_SESSION_KEY)
+        human = datetime(2026, 8, 16, 9, 0, 0)
+        spur = human + timedelta(hours=3)
+        session.messages = [
+            {"role": "user", "content": "a", "timestamp": human.isoformat()},
+            {
+                "role": "user",
+                "content": SUSTAINED_GOAL_CONTINUE_PROMPT,
+                "timestamp": spur.isoformat(),
+                INJECTED_EVENT_META: GOAL_CONTINUE_EVENT,
             },
         ]
 

--- a/tests/session/test_history_meta.py
+++ b/tests/session/test_history_meta.py
@@ -1,0 +1,132 @@
+"""Le righe ``role: "user"`` che l'utente non ha scritto, e dove il marcatore finisce.
+
+Il fatto misurato sul device il 05/09/2026: tre cose si persistono con quel ruolo
+senza essere l'utente — un turno di cron, il rientro di un subagent iniettato a
+metà turno, lo sprone a un sustained goal — e solo la prima era marcata. Le altre
+due passavano per parole dell'utente ai tre lettori che ne dipendono.
+
+Il marcatore deve stare **solo** nel JSONL: se raggiungesse l'API sarebbe un campo
+sconosciuto su un endpoint che ne rifiuta. Le due whitelist che lo trattengono sono
+verificate qui sotto, perché sono la ragione per cui è lecito appenderlo a un dict
+che è anche il payload della richiesta in corso.
+"""
+
+from __future__ import annotations
+
+from jenny.cron.session_turns import CRON_HISTORY_META
+from jenny.providers.base import LLMProvider
+from jenny.providers.openai_compat_helpers import _ALLOWABLE_MSG_KEYS
+from jenny.session.history_meta import (
+    GOAL_CONTINUE_EVENT,
+    INJECTED_EVENT_META,
+    LENGTH_RECOVERY_EVENT,
+    SUBAGENT_RESULT_EVENT,
+    is_synthetic_history_row,
+)
+from jenny.session.manager import Session
+from jenny.utils.runtime import (
+    build_budget_exhausted_finalization_message,
+    build_finalization_retry_message,
+    build_goal_continue_message,
+    build_length_recovery_message,
+)
+
+
+def test_a_typed_message_is_not_synthetic() -> None:
+    assert is_synthetic_history_row({"role": "user", "content": "ciao"}) is False
+
+
+def test_nothing_at_all_is_not_synthetic() -> None:
+    assert is_synthetic_history_row(None) is False
+    assert is_synthetic_history_row({}) is False
+
+
+def test_the_three_synthetic_rows() -> None:
+    assert is_synthetic_history_row({"role": "user", CRON_HISTORY_META: True}) is True
+    assert (
+        is_synthetic_history_row({"role": "user", INJECTED_EVENT_META: SUBAGENT_RESULT_EVENT})
+        is True
+    )
+    assert (
+        is_synthetic_history_row({"role": "user", INJECTED_EVENT_META: GOAL_CONTINUE_EVENT})
+        is True
+    )
+    assert (
+        is_synthetic_history_row({"role": "user", INJECTED_EVENT_META: LENGTH_RECOVERY_EVENT})
+        is True
+    )
+
+
+def test_the_announce_persisted_as_assistant_counts_too() -> None:
+    """Il ramo d'annuncio autonomo scrive ``role: "assistant"`` con lo stesso marcatore.
+
+    ``TurnPersistenceMixin._persist_subagent_followup`` lo usa quando il subagent
+    rientra *dopo* la fine del turno che lo ha lanciato. È lo stesso fatto, e i
+    lettori lo saltano allo stesso modo.
+    """
+    row = {"role": "assistant", INJECTED_EVENT_META: SUBAGENT_RESULT_EVENT}
+    assert is_synthetic_history_row(row) is True
+
+
+def test_an_unknown_injected_event_is_not_swallowed() -> None:
+    """Il predicato riconosce un elenco, non «ha una chiave ``injected_event``».
+
+    Un evento nuovo deve essere aggiunto di proposito: passare in silenzio
+    vorrebbe dire nascondere righe che nessuno ha deciso di nascondere.
+    """
+    assert is_synthetic_history_row({"role": "user", INJECTED_EVENT_META: "qualcosa"}) is False
+
+
+def test_the_synthetic_builders_carry_their_marker() -> None:
+    assert build_goal_continue_message()[INJECTED_EVENT_META] == GOAL_CONTINUE_EVENT
+    assert build_goal_continue_message("spronalo")[INJECTED_EVENT_META] == GOAL_CONTINUE_EVENT
+    assert build_length_recovery_message()[INJECTED_EVENT_META] == LENGTH_RECOVERY_EVENT
+
+
+def test_the_finalization_builders_stay_unmarked() -> None:
+    """Non è una dimenticanza: quei due non arrivano mai alla storia.
+
+    Finiscono in una copia della lista (``_finalization_retry_messages``,
+    ``_budget_exhausted_finalization_messages``) che serve alla richiesta e al
+    conteggio token. Marcarli direbbe il falso su dove vanno a finire.
+    """
+    assert INJECTED_EVENT_META not in build_finalization_retry_message()
+    assert INJECTED_EVENT_META not in build_budget_exhausted_finalization_message()
+
+
+def test_the_marker_never_reaches_the_provider() -> None:
+    """Prima whitelist: i provider filtrano le chiavi prima del filo.
+
+    È quel che rende lecito appendere il marcatore a un dict che è anche il
+    payload della richiesta in corso — il turno lo persiste, l'API non lo vede.
+    """
+    marked = build_goal_continue_message()
+    sanitized = LLMProvider._sanitize_request_messages([marked], _ALLOWABLE_MSG_KEYS)
+
+    assert sanitized == [{"role": "user", "content": marked["content"]}]
+
+
+def test_the_marker_does_not_survive_history_replay() -> None:
+    """Seconda whitelist: ``get_history`` ricostruisce le righe chiave per chiave.
+
+    Al turno dopo il modello rilegge un messaggio utente normale — che è quel che
+    deve vedere: il rientro del subagent *è* successo, e la conversazione non
+    deve fingere il contrario.
+    """
+    session = Session(key="websocket:replay")
+    session.messages = [
+        {
+            "role": "user",
+            "content": "[Subagent 'x' completed successfully]…",
+            INJECTED_EVENT_META: SUBAGENT_RESULT_EVENT,
+            "subagent_task_id": "ff0941f9",
+        },
+        {"role": "assistant", "content": "backup ok"},
+    ]
+
+    replayed = session.get_history()
+
+    assert replayed == [
+        {"role": "user", "content": "[Subagent 'x' completed successfully]…"},
+        {"role": "assistant", "content": "backup ok"},
+    ]

--- a/tests/session/test_webui_turns.py
+++ b/tests/session/test_webui_turns.py
@@ -24,6 +24,11 @@ from jenny.bus.runtime_events import (
 from jenny.cron.session_turns import CRON_HISTORY_META
 from jenny.providers.base import LLMResponse
 from jenny.session import webui_turns as wt
+from jenny.session.history_meta import (
+    GOAL_CONTINUE_EVENT,
+    INJECTED_EVENT_META,
+    SUBAGENT_RESULT_EVENT,
+)
 from jenny.session.keys import HEARTBEAT_SESSION_KEY
 from jenny.session.manager import Session, SessionManager
 from jenny.session.turn_visibility import silent_turn_metadata
@@ -95,6 +100,32 @@ def test_title_inputs_skips_commands_and_cron_turns():
     session.messages = [
         {"role": "user", "content": "/stop", "_command": True},
         {"role": "user", "content": "cron ping", CRON_HISTORY_META: True},
+        {"role": "user", "content": "real question"},
+        {"role": "assistant", "content": "real answer"},
+    ]
+    user_text, assistant_text = wt._title_inputs(session)
+    assert user_text == "real question"
+    assert assistant_text == "real answer"
+
+
+def test_title_inputs_skips_injected_rows():
+    """Un rientro di subagent o uno sprone a un goal non titolano la chat.
+
+    Portano ``role: "user"`` come il turno di cron qui sopra, e senza marcatore
+    il titolo della conversazione poteva diventare il prompt di un subagent.
+    """
+    session = Session(key="websocket:c2")
+    session.messages = [
+        {
+            "role": "user",
+            "content": "[Subagent 'x' completed successfully]…",
+            INJECTED_EVENT_META: SUBAGENT_RESULT_EVENT,
+        },
+        {
+            "role": "user",
+            "content": "You have an active sustained goal…",
+            INJECTED_EVENT_META: GOAL_CONTINUE_EVENT,
+        },
         {"role": "user", "content": "real question"},
         {"role": "assistant", "content": "real answer"},
     ]

--- a/tests/webui/test_webui_transcript.py
+++ b/tests/webui/test_webui_transcript.py
@@ -1172,3 +1172,86 @@ def test_two_boundaries_in_a_row_are_one_page_break(tmp_path, monkeypatch) -> No
     assert second is not None
     assert _message_contents(second) == _numbered_turn_texts(1, 2)
     assert second["page"]["has_more_before"] is False
+
+
+_SUBAGENT_ANNOUNCE = (
+    "[Subagent 'backup latest hps' completed successfully]\n\n"
+    "Task: Fai una singola chiamata al tool MCP `latest` sull'hub…\n\n"
+    "Result:\nlocale ok, remoto ok\n\n"
+    "Summarize this naturally for the user."
+)
+
+
+def test_cron_turn_does_not_backfill_a_subagent_announce_as_a_user_bubble(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Il rientro di un subagent non è una bolla dell'utente.
+
+    Misurato sul device il 05/09/2026: il turno del cron ``backup-daily-recap``
+    non ha evento ``user`` nel transcript di display (il trigger non ci passa),
+    quindi il backfill va a cercarne uno in sessione. Scartava il trigger per
+    ``_cron_turn`` e trovava subito dopo l'annuncio del subagent — iniettato a
+    metà turno con ``role: "user"`` e nessun marcatore — e lo mostrava in chat
+    con dentro il prompt integrale del subagent.
+    """
+    monkeypatch.setattr("jenny.config.paths.get_data_dir", lambda: tmp_path)
+    key = "websocket:cron-announce"
+    append_transcript_object(
+        key,
+        {"event": "message", "chat_id": "cron-announce", "text": "buongiorno papi, backup ok"},
+    )
+    append_transcript_object(key, {"event": "turn_end", "chat_id": "cron-announce"})
+
+    out = build_webui_thread_response(
+        key,
+        session_messages=[
+            {
+                "role": "user",
+                "content": "Scheduled cron job triggered: backup-daily-recap",
+                "_cron_turn": True,
+            },
+            {"role": "assistant", "content": "delego la lettura a un subagent"},
+            {
+                "role": "user",
+                "content": _SUBAGENT_ANNOUNCE,
+                "injected_event": "subagent_result",
+                "subagent_task_id": "ff0941f9",
+            },
+            {"role": "assistant", "content": "buongiorno papi, backup ok"},
+        ],
+    )
+
+    assert out is not None
+    assert [(m["role"], m["content"]) for m in out["messages"]] == [
+        ("assistant", "buongiorno papi, backup ok"),
+    ]
+
+
+def test_cron_turn_still_backfills_a_real_user_message(tmp_path, monkeypatch) -> None:
+    """Controllo positivo: senza il marcatore il backfill fa ancora il suo lavoro.
+
+    Tiene il test qui sopra onesto — deve fallire perché l'annuncio è *marcato*,
+    non perché il backfill ha smesso di funzionare.
+    """
+    monkeypatch.setattr("jenny.config.paths.get_data_dir", lambda: tmp_path)
+    key = "websocket:real-user"
+    append_transcript_object(
+        key,
+        {"event": "message", "chat_id": "real-user", "text": "buongiorno papi, backup ok"},
+    )
+    append_transcript_object(key, {"event": "turn_end", "chat_id": "real-user"})
+
+    out = build_webui_thread_response(
+        key,
+        session_messages=[
+            {"role": "user", "content": "com'è andato il backup?"},
+            {"role": "assistant", "content": "buongiorno papi, backup ok"},
+        ],
+    )
+
+    assert out is not None
+    assert [(m["role"], m["content"]) for m in out["messages"]] == [
+        ("user", "com'è andato il backup?"),
+        ("assistant", "buongiorno papi, backup ok"),
+    ]


### PR DESCRIPTION
## The bug

A `role: "user"` row in session history is the only marker Jenny has for *"the user spoke"*. Three things write one without being the user — and only the first carried a marker:

| row | marked before |
|---|---|
| cron turn | ✅ `_cron_turn` |
| subagent result injected mid-turn | ❌ |
| sustained-goal continuation | ❌ |

Measured on the Unihertz Titan 2 on 2026-09-05: **24 unmarked rows** across four live sessions (11 `project_piante`, 10 `project_salute`, 2+1 `project_memory`, 1 `unified_default`).

Three symptoms, one cause:

1. **A user bubble in chat carrying the subagent's whole input prompt.** Only on cron turns: the WebUI never records the cron trigger as a `user` event, so `_inject_missing_user_events_from_session` goes looking for one in session, skips the trigger via `_cron_turn`, finds the announce, and splices it in. Screenshot-confirmed on device.
2. **Heartbeat re-arm.** `last_user_message_ms(unified:default)` read the announce as the user showing up, re-arming an alert already sent — at night, in front of a dark screen. Exactly the case `test_heartbeat_user_rearm.py` already documents for cron.
3. **Conversation title.** `_title_inputs` skipped `_cron_turn` but not the announce.

The same subagent result arriving *after* its parent turn went through `_persist_subagent_followup`, which marks it — so whether the user saw it depended on the subagent's timing.

## The fix

**Mark at the source.** `AgentLoop._drain_pending` normalizes every queued message to `{"role": "user", ...}` — the shape the model must see — and the turn persists that shape verbatim; the `InboundMessage` metadata was the last place the two were still distinguishable. Carry `injected_event`/`subagent_task_id` through it, and mark the two synthetic builders in `utils/runtime.py`. The two finalization builders stay unmarked deliberately: their lists are copies that serve the request and token accounting and never reach history — there is a docstring and a test saying so, to stop a later "fix".

**One predicate, three readers.** New `jenny/session/history_meta.py` owns `is_synthetic_history_row()`; the cron constant is imported inside the function because a module-level import breaks the cold-import sweep (`tests/session/test_cold_imports.py`) — the same cycle already documented in `manager.py`, whose 15-line comment moved there with it.

**Not touched:** the 24 already-persisted rows (fix-forward only), the announce template, and the turn-splitting semantics of `_session_backfill_turns`.

## Why the marker is safe on an in-flight message

The dict it is appended to is also the provider payload for the rest of the turn. Two whitelists keep it off the wire — `LLMProvider._sanitize_request_messages` + `_ALLOWABLE_MSG_KEYS` (the Anthropic path rebuilds dicts explicitly) and `SessionManager.get_history` on replay. Both are now covered by tests in `tests/session/test_history_meta.py`: if either stopped filtering, the field would land on an endpoint that does not know it.

No security boundary is touched (no workspace sandbox, network guard or credential path).

## Tests

18 new. The two that carry the claim were checked with a mutant, not just watched to pass:

- **The bubble** (`test_webui_transcript.py`): disabling the predicate makes it fail printing the exact bubble from the device screenshot. A positive control sits next to it so it cannot pass by the backfill simply breaking.
- **The marking** (`test_loop_save_turn.py`): a real turn, announce pre-queued, two provider rounds. Disabling the propagation in `loop.py` makes it fail — so it genuinely goes through the injection queue.

Plus heartbeat re-arm, chat title, and the two whitelists above.

## Verification

```
ruff check jenny/ tests/          → All checks passed
npx pyright <blocking subset>     → 0 errors
python3 -m pytest -q              → 9173 passed, 7 skipped   (3.14)
python3.11 -m pytest -q           → 9172 passed, 8 skipped   (3.11, the device's Chaquopy version)
```

Pyright's 5 residual errors on the touched files outside the blocking subset are identical before and after (checked with `git stash`).

**Not tested on device:** no APK was built or installed. The end-to-end confirmation is the 08:00 cron turn after a release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)