### PR TITLE
Let a finished subagent card expire on its own clock

### DIFF
--- a/jenny/templates/ui/assets/mobile-chat.js
+++ b/jenny/templates/ui/assets/mobile-chat.js
@@ -226,6 +226,8 @@ export class ChatController {
     this._subagentSnapshot = { running: [], recent: [] };
     this._subagentsOpen = false;
     this._subagentPollTimer = null;
+    // Sveglia dell'ultimo ri-render di una card terminale (v. _scheduleSubagentExpiry).
+    this._subagentExpiryTimer = null;
     this._lastStalledIds = '';
     // Task id visti *vivi* in questo turno. È il filtro che tiene il pannello
     // sul lavoro vivo: una voce terminale si mostra solo se la sua transizione
@@ -2022,10 +2024,13 @@ export class ChatController {
 
      Il pannello mostra il LAVORO VIVO, non lo storico. Una card terminale resta
      per il turno corrente — così la transizione si vede — e sparisce a
-     `turn_end`; niente di un turno passato viene mai renderizzato, nemmeno
-     dopo un reload (il filtro sta in shared/subagent-policy.js). Il duplicato
-     era doppio danno: l'esito è già riassunto dall'orchestratore nella chat, e
-     una card recente occupava spazio sopra il composer per sempre.
+     `turn_end`, o al più tardi alla propria scadenza di orologio, perché
+     `turn_end` è un frame live che a un client in Doze non arriva mai
+     (v. SA_LINGER_MS); niente di un turno passato viene mai renderizzato,
+     nemmeno dopo un reload (il filtro sta in shared/subagent-policy.js). Il
+     duplicato era doppio danno: l'esito è già riassunto dall'orchestratore
+     nella chat, e una card recente occupava spazio sopra il composer per
+     sempre.
 
      Le due cose che il pannello deve rendere ovvie sono `idle` (fermo ≠ al
      lavoro) e Stop. Con più di un subagent le card stanno su UNA riga che scorre
@@ -2133,6 +2138,7 @@ export class ChatController {
     this._subagentLiveIds = view.liveIds;
     const lingering = view.lingering;
     const total = running.length + lingering.length;
+    this._scheduleSubagentExpiry(view.nextExpiryMs);
 
     // Zero card = pannello assente, non pannello chiuso: sopra il composer
     // nemmeno i 34px dell'header collassato sono gratis.
@@ -2189,6 +2195,30 @@ export class ChatController {
   _dropTerminatedSubagents() {
     this._subagentLiveIds = new Set();
     this._renderSubagents(this._subagentSnapshot);
+  }
+
+  /* L'ultimo ri-render di una card terminale: quello che la fa sparire quando
+     `turn_end` non arriva (v. SA_LINGER_MS). Un timer solo, riarmato a ogni
+     render sulla prima scadenza, perché è l'unico evento che resta — il poll a
+     zero running è spento per scelta, e senza sveglia la scadenza sarebbe una
+     regola che nessuno applica.
+
+     Il timer non chiede niente al gateway: ri-renderizza lo snapshot che si ha
+     già, così una card scaduta cade anche offline. Se Android ha strozzato il
+     timer mentre la vista era nascosta, al ritorno in foreground il
+     visibilitychange fa comunque una lettura. */
+  _scheduleSubagentExpiry(nextExpiryMs) {
+    if (this._subagentExpiryTimer) {
+      clearTimeout(this._subagentExpiryTimer);
+      this._subagentExpiryTimer = null;
+    }
+    if (!Number.isFinite(nextExpiryMs)) return;
+    // +50ms: un timer che scatta *sul* confine trova la card ancora fresca di
+    // un millisecondo e si riarma a zero, in un ciclo che non finisce.
+    this._subagentExpiryTimer = setTimeout(() => {
+      this._subagentExpiryTimer = null;
+      this._renderSubagents(this._subagentSnapshot);
+    }, Math.max(0, nextExpiryMs) + 50);
   }
 
   /* Traduzione con fallback sul valore grezzo: phase e state arrivano dal

--- a/jenny/templates/ui/assets/shared/subagent-policy.js
+++ b/jenny/templates/ui/assets/shared/subagent-policy.js
@@ -15,10 +15,46 @@
 
 /* Stati terminali: il subagent non è più in gioco. Il pannello mostra il LAVORO
    VIVO, quindi una card terminale non è storia — è la transizione, che va vista
-   una volta. Resta per il turno corrente e sparisce a `turn_end`; lo storico
-   vero è nella chat (l'orchestratore riassume ogni esito) e nei record su
-   disco. */
+   una volta. Resta per il turno corrente e sparisce a `turn_end`, o comunque
+   scade da sé dopo `SA_LINGER_MS` se quel frame non arriva mai; lo storico vero
+   è nella chat (l'orchestratore riassume ogni esito) e nei record su disco. */
 export const SA_TERMINAL_STATES = ['done', 'failed', 'cancelled'];
+
+/* Quanto vive una card terminale se `turn_end` non arriva mai. `turn_end` resta
+   il modo normale in cui una card sparisce, ma è un frame **live**: nessuno lo
+   ritrasmette a chi non era connesso. Su questo telefono non essere connessi è
+   la norma — Doze, schermo spento, WebView strozzata — e un turno di cron
+   consegnato in quella finestra lascia il pannello senza il proprio sweeper: il
+   client si riattacca, la cronologia ridipinge i messaggi, `liveIds` sopravvive
+   in memoria e il primo poll ripesca il terminato da `recent`. Misurato sul
+   Titan 2: la card di un subagent finito alle 07:00 stava ancora sopra il
+   composer alle 10:18, con un turn_end (08:00) passato nel frattempo.
+
+   L'altra metà dello stesso buco è per costruzione: un subagent ancora vivo a
+   `turn_end` si re-iscrive (v. saVisibleCards), quindi terminerà *dopo* il solo
+   evento che l'avrebbe spazzato — e su un install guidato dai cron il turno
+   successivo può essere a ore di distanza.
+
+   Il tetto è di orologio di parete e non di turni, perché è la freschezza che
+   giustifica la card: la transizione va vista, e dopo un minuto non c'è più
+   niente da vedere. */
+export const SA_LINGER_MS = 60_000;
+
+/* `ended_at` assente o non numerico = freschezza ignota, quindi scaduta: una
+   card che non sa dimostrare di essere appena nata non merita lo spazio sopra il
+   composer. In pratica non capita — ``ended_at`` è ``time.time()`` su ogni
+   record terminale — ma il default deve cadere dalla parte del pannello vuoto. */
+function saEndedAtMs(entry) {
+  const ended = Number(entry?.ended_at);
+  return Number.isFinite(ended) && ended > 0 ? ended * 1000 : NaN;
+}
+
+/** Millisecondi rimasti a una card terminale, 0 se è già scaduta. */
+export function saLingerLeftMs(entry, now = Date.now()) {
+  const endedAt = saEndedAtMs(entry);
+  if (!Number.isFinite(endedAt)) return 0;
+  return Math.max(0, endedAt + SA_LINGER_MS - now);
+}
 
 /* Matrice delle azioni, per stato e per superficie. Tabella e non if/else
    perché è la regola, e il test la rilegge da qui.
@@ -68,17 +104,43 @@ export function saIsTerminal(state) {
  *
  * Ritorna anche `liveIds` aggiornato: i vivi di adesso restano ammessi a
  * lingerare quando termineranno, anche se il turno intanto è finito (un
- * subagent può sopravvivere al turno che l'ha lanciato).
+ * subagent può sopravvivere al turno che l'ha lanciato). Un terminato scaduto
+ * (v. SA_LINGER_MS) invece *esce* da `liveIds`: senza questo il poll successivo
+ * lo ripescherebbe da `recent`, e la scadenza sarebbe un filtro che dimentica.
+ *
+ * `nextExpiryMs` è quanto manca alla prima scadenza fra le card mostrate, o
+ * `null` se non ce ne sono. Serve al chiamante per programmare l'ultimo
+ * ri-render: a zero running non c'è nessun poll che lo faccia da sé, e una
+ * scadenza che nessuno guarda non fa sparire niente.
  */
-export function saVisibleCards(snapshot, liveIds) {
+export function saVisibleCards(snapshot, liveIds, now = Date.now()) {
   const running = Array.isArray(snapshot?.running) ? snapshot.running : [];
   const recent = Array.isArray(snapshot?.recent) ? snapshot.recent : [];
   const live = new Set(liveIds || []);
+  const aliveNow = new Set();
   for (const entry of running) {
-    if (entry && entry.task_id) live.add(String(entry.task_id));
+    if (entry && entry.task_id) {
+      live.add(String(entry.task_id));
+      aliveNow.add(String(entry.task_id));
+    }
   }
-  const lingering = recent.filter(e => e && live.has(String(e.task_id)));
-  return { running, lingering, liveIds: live };
+  const lingering = [];
+  let nextExpiryMs = null;
+  for (const entry of recent) {
+    const taskId = entry && entry.task_id ? String(entry.task_id) : '';
+    if (!taskId || !live.has(taskId)) continue;
+    // Uno stesso id vivo *e* in `recent` non capita, ma se capitasse la card
+    // viva è quella che conta: la scadenza non deve poterla sfrattare.
+    if (aliveNow.has(taskId)) continue;
+    const left = saLingerLeftMs(entry, now);
+    if (left <= 0) {
+      live.delete(taskId);
+      continue;
+    }
+    lingering.push(entry);
+    if (nextExpiryMs === null || left < nextExpiryMs) nextExpiryMs = left;
+  }
+  return { running, lingering, liveIds: live, nextExpiryMs };
 }
 
 /* ══════════════════════════════════════════════════════════════════════════

--- a/tests/webui/test_subagent_panel_policy.py
+++ b/tests/webui/test_subagent_panel_policy.py
@@ -6,14 +6,18 @@ descriverle con una regex. Il modulo viene valutato da node (già richiesto dal
 type check con ``npx pyright``) e le asserzioni sono in JS, sullo stesso oggetto
 che la WebUI usa a runtime.
 
-Le tre regole che questi test difendono, in ordine di quanto costa perderle:
+Le quattro regole che questi test difendono, in ordine di quanto costa perderle:
 
 1. Nulla di un turno passato viene mai renderizzato. Il server serve sempre
    ``recent`` (lo consumano il tool ``subagent_status`` e GET /api/subagents), e
    dopo un reload quella coda contiene i job dei turni precedenti: se il pannello
    li ripescasse, l'utente ritroverebbe card morte sopra il composer per sempre.
 2. Una card terminale lingera per il turno corrente e sparisce a ``turn_end``.
-3. La matrice delle azioni per stato: Rilancia non deve comparire su un job
+3. ...e comunque scade da sé dopo ``SA_LINGER_MS``. ``turn_end`` è un frame
+   live: chi era in Doze non lo riceve mai, e senza scadenza la card resta
+   sopra il composer per ore (misurato sul Titan 2: una card delle 07:00 ancora
+   lì alle 10:18).
+4. La matrice delle azioni per stato: Rilancia non deve comparire su un job
    riuscito né a un tap su un job fallito.
 """
 
@@ -84,28 +88,80 @@ def test_a_reload_with_nothing_running_renders_an_empty_panel() -> None:
 def test_a_terminated_card_lingers_only_for_the_current_turn() -> None:
     """Vivo → terminato (lingera) → turn_end (sparisce)."""
     _run_js("""
+      const NOW = 1700000000000;
       let live = new Set();
 
       // 1. Il subagent gira: una card viva, nessuna terminale.
-      let view = saVisibleCards({ running: [{ task_id: 't1', state: 'running' }], recent: [] }, live);
+      let view = saVisibleCards({ running: [{ task_id: 't1', state: 'running' }], recent: [] }, live, NOW);
       live = view.liveIds;
       assert.equal(view.running.length, 1);
       assert.deepEqual(view.lingering, []);
 
       // 2. Termina: il server lo sposta in `recent`, la card lingera perché la
       //    transizione è stata osservata qui.
-      const terminated = { running: [], recent: [{ task_id: 't1', state: 'done' }] };
-      view = saVisibleCards(terminated, live);
+      const terminated = {
+        running: [],
+        recent: [{ task_id: 't1', state: 'done', ended_at: NOW / 1000 - 1 }],
+      };
+      view = saVisibleCards(terminated, live, NOW);
       live = view.liveIds;
       assert.deepEqual(view.lingering.map(e => e.task_id), ['t1']);
 
       // 3. turn_end azzera l'insieme dei vivi: la card non c'è più, e non torna
       //    nemmeno al poll successivo che riporta lo stesso `recent`.
       live = new Set();
-      view = saVisibleCards(terminated, live);
+      view = saVisibleCards(terminated, live, NOW);
       assert.deepEqual(view.lingering, []);
-      view = saVisibleCards(terminated, view.liveIds);
+      view = saVisibleCards(terminated, view.liveIds, NOW);
       assert.deepEqual(view.lingering, []);
+    """)
+
+
+def test_a_terminated_card_expires_without_any_turn_end() -> None:
+    """Il buco misurato: nessun ``turn_end``, e la card resta sopra il composer.
+
+    ``turn_end`` è un frame live — un turno di cron consegnato mentre il telefono
+    è in Doze non lo consegna a nessuno. Senza scadenza la card sopravvive a
+    tutto: al poll, al reconnect, e anche ai turn_end successivi che il client
+    non ha visto.
+    """
+    _run_js("""
+      const NOW = 1700000000000;
+      const snapshot = {
+        running: [],
+        recent: [{ task_id: 't1', state: 'done', ended_at: NOW / 1000 }],
+      };
+      // Appena terminato: la transizione si deve vedere.
+      let view = saVisibleCards(snapshot, new Set(['t1']), NOW + 1000);
+      assert.deepEqual(view.lingering.map(e => e.task_id), ['t1']);
+      assert.ok(view.nextExpiryMs > 0 && view.nextExpiryMs <= SA_LINGER_MS);
+
+      // Un istante dopo la scadenza: pannello vuoto, senza che sia arrivato
+      // niente dal gateway.
+      view = saVisibleCards(snapshot, new Set(['t1']), NOW + SA_LINGER_MS + 1);
+      assert.deepEqual(view.lingering, []);
+      assert.equal(view.nextExpiryMs, null);
+      // E l'id esce dai vivi: il poll successivo non lo ripesca da `recent`.
+      assert.ok(!view.liveIds.has('t1'), 'una scadenza che dimentica non è una scadenza');
+    """)
+
+
+def test_freshness_is_wall_clock_and_unknown_means_expired() -> None:
+    """``ended_at`` assente o assurdo = card che non prova di essere fresca."""
+    _run_js("""
+      const NOW = 1700000000000;
+      for (const ended of [undefined, null, 0, -1, 'ieri', NaN]) {
+        const view = saVisibleCards(
+          { running: [], recent: [{ task_id: 't1', state: 'done', ended_at: ended }] },
+          new Set(['t1']),
+          NOW,
+        );
+        assert.deepEqual(view.lingering, [], `ended_at=${String(ended)} non deve lingerare`);
+      }
+      // Un `ended_at` nel futuro (orologio del telefono spostato) non pinna la
+      // card per sempre: al massimo vale una finestra intera.
+      const ahead = saLingerLeftMs({ ended_at: NOW / 1000 + 3600 }, NOW);
+      assert.ok(ahead > 0, 'una card dal futuro resta visibile');
     """)
 
 
@@ -118,7 +174,12 @@ def test_turn_end_never_drops_a_subagent_that_outlived_the_turn() -> None:
       assert.equal(view.running.length, 1);
       assert.ok(view.liveIds.has('t1'), 'un vivo si re-iscrive da sé');
       // E quando poi terminerà, la sua card lingera come le altre.
-      const after = saVisibleCards({ running: [], recent: [{ task_id: 't1', state: 'failed' }] }, view.liveIds);
+      const now = Date.now();
+      const after = saVisibleCards(
+        { running: [], recent: [{ task_id: 't1', state: 'failed', ended_at: now / 1000 }] },
+        view.liveIds,
+        now,
+      );
       assert.deepEqual(after.lingering.map(e => e.task_id), ['t1']);
     """)
 
@@ -126,13 +187,14 @@ def test_turn_end_never_drops_a_subagent_that_outlived_the_turn() -> None:
 def test_only_the_witnessed_terminations_linger() -> None:
     """Fra i terminati di `recent` passa solo quello visto vivo in questo turno."""
     _run_js("""
+      const now = Date.now();
       const view = saVisibleCards({
         running: [],
         recent: [
-          { task_id: 'seen', state: 'done' },
-          { task_id: 'from-an-old-turn', state: 'done' },
+          { task_id: 'seen', state: 'done', ended_at: now / 1000 },
+          { task_id: 'from-an-old-turn', state: 'done', ended_at: now / 1000 },
         ],
-      }, new Set(['seen']));
+      }, new Set(['seen']), now);
       assert.deepEqual(view.lingering.map(e => e.task_id), ['seen']);
     """)
 

--- a/tests/webui/test_subagent_panel_wiring.py
+++ b/tests/webui/test_subagent_panel_wiring.py
@@ -47,6 +47,29 @@ def test_turn_end_drops_the_terminated_cards() -> None:
     assert "_renderSubagents(" in body
 
 
+def test_the_expiry_has_a_wakeup_of_its_own() -> None:
+    """La scadenza di una card terminale va *applicata*, non solo calcolata.
+
+    A zero running il poll è spento per scelta, quindi l'unico evento che resta
+    è un timer: senza di lui una card scaduta se ne sta a schermo fino al
+    prossimo frame, che su un install guidato dai cron può essere fra ore — che
+    è esattamente il difetto che la scadenza doveva chiudere.
+    """
+    source = _chat()
+    render = re.search(r"_renderSubagents\(snapshot\)\s*\{(.*?)\n  \}", source, re.S)
+    assert render, "_renderSubagents non trovato"
+    assert "_scheduleSubagentExpiry(view.nextExpiryMs)" in render.group(1)
+    sched = re.search(r"_scheduleSubagentExpiry\(nextExpiryMs\)\s*\{(.*?)\n  \}", source, re.S)
+    assert sched, "_scheduleSubagentExpiry non trovato"
+    body = sched.group(1)
+    # Un timer solo, riarmato: due sveglie sovrapposte renderizzano due volte.
+    assert "clearTimeout(this._subagentExpiryTimer)" in body
+    assert "setTimeout(" in body
+    # Ri-render dello snapshot che si ha già: la card deve cadere anche offline.
+    assert "_renderSubagents(this._subagentSnapshot)" in body
+    assert "api." not in body and "fetch(" not in body
+
+
 def test_the_panel_is_hidden_when_there_are_no_cards() -> None:
     """Zero card = elemento `hidden`, non pannello collassato."""
     source = _chat()


### PR DESCRIPTION
A terminal subagent card used to leave the panel only on `turn_end` — a **live** frame that nobody retransmits. On this phone not being connected is the norm (Doze, screen off, a throttled WebView), so a cron turn delivered in that window leaves the panel without its sweeper: measured on a Unihertz Titan 2, the card of a subagent that finished at 07:00 was still sitting above the composer at 10:18, with an 08:00 `turn_end` gone by in between.

The other half is structural: a subagent still alive at `turn_end` re-registers, so it terminates *after* the only event that would have swept it — and on a cron-driven install the next turn can be hours away.

## What changes

- `SA_LINGER_MS` caps a terminal card at 60 s of wall clock. Freshness is what justifies the card: the transition is worth seeing, and after a minute there is nothing left to see.
- An expired card also leaves `liveIds`, otherwise the next poll fishes it back out of `recent` and the expiry becomes a filter that forgets.
- `saVisibleCards` now reports `nextExpiryMs`, and the client arms a single timer on it — the one re-render that makes the card disappear when no poll will. The timer asks the gateway for nothing: it re-renders the snapshot already in hand, so an expired card falls away offline too.
- A missing or non-numeric `ended_at` counts as expired: a card that cannot prove it is fresh does not earn the space above the composer.

## Provenance

This is a parallel Claude Code session's work, sitting uncommitted in a shared working tree. Committed and opened here at the repository owner's explicit request to get the tree clean. The reasoning above is read off the diff and its comments, not authored here — if the parallel session had more to add, it should say so on this PR before merge.

Tests: `ruff` clean and the full suite green (9201 passed) with these changes on top of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)