### PR TITLE
Send tool-result images to the Responses API as images

### DIFF
--- a/jenny/providers/openai_responses/converters.py
+++ b/jenny/providers/openai_responses/converters.py
@@ -54,8 +54,11 @@ def convert_messages(messages: list[dict[str, Any]]) -> tuple[str, list[dict[str
 
         if role == "tool":
             call_id, _ = split_tool_call_id(msg.get("tool_call_id"))
-            output_text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
-            input_items.append({"type": "function_call_output", "call_id": call_id, "output": output_text})
+            input_items.append({
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": convert_tool_output(content),
+            })
 
     return system_prompt, input_items
 
@@ -73,15 +76,43 @@ def convert_user_message(content: Any) -> dict[str, Any]:
         for item in content:
             if not isinstance(item, dict):
                 continue
-            if item.get("type") == "text":
-                converted.append({"type": "input_text", "text": item.get("text", "")})
-            elif item.get("type") == "image_url":
-                url = (item.get("image_url") or {}).get("url")
-                if url:
-                    converted.append({"type": "input_image", "image_url": url, "detail": "auto"})
+            part = _input_part(item)
+            if part is not None:
+                converted.append(part)
         if converted:
             return {"role": "user", "content": converted}
     return {"role": "user", "content": [{"type": "input_text", "text": ""}]}
+
+
+def convert_tool_output(content: Any) -> str | list[dict[str, Any]]:
+    """Rende il contenuto di un messaggio ``tool`` come ``output``.
+
+    ``function_call_output.output`` accetta **o** una stringa **o** una lista
+    di input part (``input_text`` / ``input_image`` / ``input_file``): la
+    stessa forma del contenuto di un messaggio utente. Serializzare a JSON una
+    lista di blocchi spenderebbe il file intero come testo e lascerebbe al
+    modello l'impalcatura invece dell'immagine — ``read_file`` su un'immagine
+    ritorna proprio quello (``utils.helpers.build_image_content_blocks``: un
+    blocco ``image_url`` con un data URI, più un blocco ``text``).
+
+    È lo stesso difetto chiuso sul ramo Anthropic in
+    ``anthropic_conversion._tool_result_block``, e qui era più insidioso: lì
+    l'API rifiutava i blocchi non convertiti e la rete di
+    ``base.py`` lasciava un log, mentre ``json.dumps`` riesce sempre.
+
+    La conversione scatta **solo** quando la lista porta un blocco immagine:
+    per tutto il resto resta il JSON di prima, che è il comportamento su cui
+    poggiano i tool che ritornano dati strutturati.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list) and _has_image_block(content):
+        parts = _tool_output_parts(content)
+        if parts:
+            return parts
+        # Ci si arriva solo con blocchi immagine privi di URL: non c'è nulla da
+        # mostrare e, per definizione, nessun base64 da versare nel prompt.
+    return json.dumps(content, ensure_ascii=False)
 
 
 def convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -100,6 +131,56 @@ def convert_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "parameters": params if isinstance(params, dict) else {},
         })
     return converted
+
+
+def _input_part(block: dict[str, Any]) -> dict[str, Any] | None:
+    """Traduce un blocco di contenuto in una input part della Responses API.
+
+    Ritorna ``None`` quando il blocco non è rappresentabile — tipo ignoto, o
+    un ``image_url`` senza URL. Chi chiama decide se saltarlo (contenuto
+    utente) o degradarlo a testo (output di un tool, dove perdere un pezzo in
+    silenzio nasconde metà del risultato).
+    """
+    kind = block.get("type")
+    if kind == "text":
+        return {"type": "input_text", "text": block.get("text", "")}
+    if kind == "image_url":
+        url = (block.get("image_url") or {}).get("url")
+        if url:
+            return {"type": "input_image", "image_url": url, "detail": "auto"}
+    return None
+
+
+def _has_image_block(content: list[Any]) -> bool:
+    """True se la lista porta almeno un blocco immagine."""
+    return any(
+        isinstance(item, dict) and item.get("type") == "image_url" for item in content
+    )
+
+
+def _tool_output_parts(content: list[Any]) -> list[dict[str, Any]]:
+    """Converte i blocchi di un tool result in input part.
+
+    A differenza del contenuto utente, qui un blocco non rappresentabile non
+    si salta: diventa testo. Un tool result è una risposta a una domanda del
+    modello, e un pezzo sparito in silenzio è peggio di un pezzo grezzo. Le
+    sole eccezioni sono i blocchi immagine inutilizzabili (nessun URL), che
+    non hanno niente da dire.
+    """
+    parts: list[dict[str, Any]] = []
+    for item in content:
+        if isinstance(item, dict):
+            part = _input_part(item)
+            if part is not None:
+                parts.append(part)
+                continue
+            if item.get("type") == "image_url":
+                continue
+            text = json.dumps(item, ensure_ascii=False)
+        else:
+            text = str(item)
+        parts.append({"type": "input_text", "text": text})
+    return parts
 
 
 def _unique_item_id(item_id: str, used: set[str]) -> str:

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from jenny.providers.openai_compat_provider import OpenAICompatProvider
 from jenny.providers.openai_responses.converters import (
     convert_messages,
     convert_tools,
@@ -270,6 +271,164 @@ class TestConvertMessages:
         assert items[0]["role"] == "user"
         assert items[1]["type"] == "function_call"
         assert items[2]["type"] == "function_call_output"
+
+
+# ======================================================================
+# converters - tool result image content
+# ======================================================================
+
+
+class TestToolResultImageContent:
+    """``read_file`` su un'immagine ritorna blocchi ``image_url``.
+
+    Stessa famiglia del difetto chiuso sul ramo Anthropic (v.
+    ``tests/providers/test_anthropic_tool_result.py``): lì i blocchi arrivavano
+    non convertiti e l'API li rifiutava, qui ``json.dumps`` riusciva sempre e
+    versava il data URI nel prompt come testo, senza errore e senza traccia.
+
+    ``function_call_output.output`` accetta una lista di input part, quindi la
+    consegna non è un segnaposto: è l'immagine.
+    """
+
+    DATA_URI = "data:image/png;base64,QUJDREVG"
+    IMAGE_BLOCKS = [
+        {
+            "type": "image_url",
+            "image_url": {"url": DATA_URI},
+            "_meta": {"path": "/w/shot.png"},
+        },
+        {"type": "text", "text": "(Image file: shot.png)"},
+    ]
+
+    @staticmethod
+    def _tool_output(content):
+        _, items = convert_messages([{
+            "role": "tool", "tool_call_id": "c1", "name": "read_file",
+            "content": content,
+        }])
+        assert items[0]["type"] == "function_call_output"
+        return items[0]["output"]
+
+    def test_image_block_becomes_a_native_input_image(self):
+        """Il difetto: era un data URI dentro una stringa JSON."""
+        output = self._tool_output(self.IMAGE_BLOCKS)
+        assert isinstance(output, list)
+        assert output[0] == {
+            "type": "input_image", "image_url": self.DATA_URI, "detail": "auto",
+        }
+
+    def test_no_json_scaffolding_reaches_the_model(self):
+        """La prova del difetto: nessun blocco serializzato come testo.
+
+        Con il difetto l'output era ``'[{"type": "image_url", ...}]'``, cioè il
+        modello leggeva l'impalcatura e il base64 al posto dell'immagine.
+        """
+        output = self._tool_output(self.IMAGE_BLOCKS)
+        rendered = json.dumps(output, ensure_ascii=False)
+        assert '"type": "image_url"' not in rendered
+        assert '\"type\": \"image_url\"' not in rendered
+
+    def test_sibling_text_block_survives(self):
+        """Il testo che accompagna l'immagine resta, come input_text."""
+        output = self._tool_output(self.IMAGE_BLOCKS)
+        assert {"type": "input_text", "text": "(Image file: shot.png)"} in output
+
+    def test_meta_never_goes_on_the_wire(self):
+        """``_meta`` è nostro: l'API non lo conosce e lo rifiuterebbe."""
+        output = self._tool_output(self.IMAGE_BLOCKS)
+        assert "_meta" not in json.dumps(output, ensure_ascii=False)
+
+    def test_unusable_image_block_is_dropped_not_stringified(self):
+        """Un ``image_url`` senza URL non ha nulla da dire: si salta."""
+        output = self._tool_output([
+            {"type": "image_url", "image_url": {"url": self.DATA_URI}},
+            {"type": "image_url", "image_url": {}},
+        ])
+        assert output == [
+            {"type": "input_image", "image_url": self.DATA_URI, "detail": "auto"},
+        ]
+
+    def test_unknown_block_is_degraded_to_text_not_lost(self):
+        """In un tool result un pezzo sparito in silenzio è peggio di uno grezzo."""
+        output = self._tool_output([
+            {"type": "image_url", "image_url": {"url": self.DATA_URI}},
+            {"type": "resource", "uri": "file:///w/a.bin"},
+        ])
+        assert output[0]["type"] == "input_image"
+        assert output[1]["type"] == "input_text"
+        assert "file:///w/a.bin" in output[1]["text"]
+
+    def test_image_only_list_without_url_falls_back_to_json(self):
+        """Nessuna part costruibile: si torna al JSON, che qui non porta base64."""
+        content = [{"type": "image_url", "image_url": {}}]
+        assert self._tool_output(content) == json.dumps(content, ensure_ascii=False)
+
+    def test_text_only_list_keeps_json_behaviour(self):
+        """Regressione: senza immagini la serializzazione resta quella di prima."""
+        content = [{"type": "text", "text": "riga 1"}, {"type": "text", "text": "riga 2"}]
+        assert self._tool_output(content) == json.dumps(content, ensure_ascii=False)
+
+    def test_string_content_untouched(self):
+        """Il caso normale — una stringa — non passa da nessuna conversione."""
+        assert self._tool_output("plain result") == "plain result"
+
+    def test_dict_content_keeps_json_behaviour(self):
+        """Un dict non è una lista di blocchi: resta JSON."""
+        content = {"temp": 72}
+        assert self._tool_output(content) == json.dumps(content, ensure_ascii=False)
+
+
+class TestResponsesBodyCarriesToolImages:
+    """Le due strade — ``chat`` e ``chat_stream`` — hanno un solo convertitore.
+
+    ``_build_responses_body`` è il punto in cui entrambe passano
+    (``openai_compat_provider.py``), quindi provarlo una volta copre lo
+    streaming e il non-streaming; il sanitizer dei messaggi sta in mezzo, ed è
+    l'altro posto in cui l'immagine potrebbe perdersi.
+    """
+
+    @staticmethod
+    def _provider():
+        p = OpenAICompatProvider.__new__(OpenAICompatProvider)
+        p.default_model = "gpt-5"
+        p._spec = type("Spec", (), {"name": "openai"})()
+        p._effective_base = "https://api.openai.com/v1"
+        p.api_base = "https://api.openai.com/v1"
+        p._api_type = "responses"
+        p._responses_failures = {}
+        p._responses_tripped_at = {}
+        p._extra_body = {}
+        return p
+
+    def test_tool_image_survives_the_whole_body_build(self):
+        messages = [
+            {"role": "user", "content": "guarda questa"},
+            {
+                "role": "assistant", "content": None,
+                "tool_calls": [
+                    {"id": "c1|fc1", "function": {"name": "read_file", "arguments": "{}"}},
+                ],
+            },
+            {
+                "role": "tool", "tool_call_id": "c1", "name": "read_file",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,QUJDREVG"},
+                        "_meta": {"path": "/w/shot.png"},
+                    },
+                    {"type": "text", "text": "(Image file: shot.png)"},
+                ],
+            },
+        ]
+        body = self._provider()._build_responses_body(
+            messages, None, "gpt-5", 100, 0.0, None, None,
+        )
+        outputs = [i for i in body["input"] if i.get("type") == "function_call_output"]
+        output = outputs[0]["output"]
+        assert output[0]["type"] == "input_image"
+        assert output[0]["image_url"] == "data:image/png;base64,QUJDREVG"
+        assert "_meta" not in json.dumps(body["input"], ensure_ascii=False)
 
 
 # ======================================================================


### PR DESCRIPTION
## The defect

`read_file` on an image returns `build_image_content_blocks` — a list holding an `image_url` data URI plus a text block. The Responses converter serialised any non-string tool content with `json.dumps`, so on that path the model received **the whole data URI as text**: no picture, and a token cost proportional to the file size.

Nothing upstream stopped it:

- `read_file` is in `_TOOL_RESULT_OFFLOAD_EXEMPT_TOOLS` (`agent/runner.py:96`), so no offload and no truncation;
- `stringify_text_blocks` (`utils/helpers.py:441`) bails on the first non-`text` block, so `maybe_persist_tool_result` hands the list through untouched;
- `read_file` has no size cap on images at all.

It is the same defect already closed on the Anthropic side (`tests/providers/test_anthropic_tool_result.py`), but quieter: there the API rejected the unconverted blocks and the retry-without-images net in `providers/base.py` left a log line, while `json.dumps` always succeeds — no error, no retry, no trace.

Exposed configurations: `api_type: "responses"` (mandatory, the circuit breaker is deliberately skipped), or `auto` with a direct OpenAI base and a reasoning model. In the second case the breaker does not help — it opens on errors, and there were none.

## Why the image travels natively

`function_call_output.output` accepts a list of input parts, not just a string — `openai-python` v3.11.0, `response_input_item_param.FunctionCallOutput`:

```python
output: Required[Union[str, ResponseFunctionCallOutputItemListParam]]
"""Text, image, or file output of the function tool call."""
```

with the item being `Union[input_text, input_image, input_file]`. So this is a real fix, not a graceful placeholder.

## The four decisions

- **One block translator.** `_input_part` does `text → input_text` and `image_url → input_image`, shared with `convert_user_message`, whose behaviour is unchanged and still covered by the tests that were already there.
- **Convert only when the list carries an image.** Every other shape keeps the previous `json.dumps`, so tools returning structured data are untouched, and the "no base64 as text" invariant follows from the condition itself. The alternative rule — convert when the list is all content — had a hole: image + unknown block would have fallen back to `json.dumps`, i.e. back to the defect.
- **An unrenderable block inside a tool result degrades to text instead of being dropped.** The opposite of the choice for user content, and for a reason: a tool result answers a question the model asked, and a piece that vanishes silently is worse than a raw one.
- **`_meta` stays off the wire.** It is ours (`build_image_content_blocks` stamps it, `turn_persistence` reads it) and the API does not know it; a test asserts its absence rather than inferring it.

No new logging: with the image passing natively there is nothing left to degrade. An endpoint that declares `api_type: responses` and *rejects* input parts is already covered by `providers/base.py:680-689`, which strips images and retries — that net walks `tool` message content too.

## Tests

Ten new tests in `TestToolResultImageContent`, plus `TestResponsesBodyCarriesToolImages`, which builds the real request through `_build_responses_body` — the single point both `chat` and `chat_stream` pass through, with the message sanitizer in between.

Neutralising the new branch turns **5 of the 10 red**; the other five are guards against information loss, not detectors.

| | |
|---|---|
| `ruff check jenny/ tests/` | clean |
| `pyright` on the blocking subset | 0 errors |
| `pytest -q` on 3.14 | 9,261 passed, 7 skipped |
| `pytest -q` on 3.11 (the device's version) | 9,253 passed |

Also verified on the device (Unihertz Titan 2, release build): the packaged `converters.py` inside the APK is byte-identical to the tree, the `.pyc` carries the new symbols, and the app runs with the gateway answering.

## Not covered here

`read_file` still has no size cap on images, on any provider — a 3 MB PNG is roughly 1M tokens whichever path it takes, while the WebUI ingest path caps uploads at 10 MB. That is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)