### PR TITLE
Show what is scheduled, and what only looks scheduled

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -134,6 +134,24 @@ Everything about Jenny surviving a screen that's been off for hours. It sits bet
 
 Only the wake-lock mode is editable here; the rest of the `power.*` family (wake-lock rotation, the restart watchdog, alarm-driven cron, the alarm-clock fallback, the outage threshold) is `config.json`-only — see [Configuration](./configuration.md#power). Outside the Android app the whole section is hidden: there is no bridge to ask, and nothing it says would be true.
 
+## Scheduling
+
+Read-only. Everything scheduled — your own reminders and the four system jobs — with what each one did last time and what it will do next. It sits between Background activity and SSH, because a job that slips is nearly always a job the battery manager delayed, and it opens by itself when there is something worth interrupting you for.
+
+Nothing here is editable, and that is deliberate: reminders are created, changed and removed by asking Jenny (the `cron` tool is the single writer on the file), and a "run now" button would queue a real model turn — spending tokens and possibly sending you a message — from a panel you opened to look at something.
+
+| What it shows | Why |
+|---|---|
+| **One card per job**, with its schedule, when it runs next, and how the last run ended | The five outcomes are not colour-coded alike: `silenced` means a monitor looked and had nothing to report, which is success, not a warning. `could not check` is the third state — it ran, but the check did not happen — and stays distinct from `error`. |
+| **Overdue instead of a past date** | Next-run times are stored, not computed on the fly: they are recalculated at startup and after each run. With the scheduler stopped, or right after the phone comes back from a long doze, the stored time is in the past — so the panel says "overdue" instead of "next run: yesterday at 22:30". |
+| **Armed but does nothing** | A system job survives the setting that created it: switch a worker off and its job stays scheduled, its handler returns immediately, and the run is recorded as `ok`. Only this panel can tell you the difference between "healthy" and "does nothing, punctually". |
+| **The Heartbeat checklist** | For the heartbeat job only: the tasks actually present in `HEARTBEAT.md`, each marked fine, not running, or handed to a subagent. An empty checklist gets said out loud — see [Scheduling and proactivity](../using/scheduling.md#heartbeat-a-periodic-checklist). |
+| **A rebuilt list** | If `cron/jobs.json` was recovered at startup, the panel says so above the list, not just in the notice at the top of the screen: a short list looks like a correct list. |
+| **Times in the job's own timezone** | A job created with an explicit timezone is shown in it, named only when it differs from the phone's — so the panel and what Jenny says in chat never disagree. |
+| **"As of HH:MM", with a Refresh button** | The panel does not poll. On a phone where scheduled work is kept punctual through deep doze, a screen that wakes the gateway every few seconds would undo that; so it reads once when you open the section, and the timestamp says it is a snapshot. |
+
+Tapping a card opens its details: the reminder's full text, the last 20 runs with durations and errors, and — for the heartbeat — the checklist.
+
 ## SSH
 
 Its own section between Background activity and Telegram, holding the two decisions that cannot be delegated to the agent: **which machines exist**, and **which host key is the right one**.

--- a/docs/using/scheduling.md
+++ b/docs/using/scheduling.md
@@ -112,6 +112,8 @@ Since 0.6.6 that file is handled the same way as `config.json`. Jenny keeps the 
 
 That notice matters more here than it does for settings. A reminder that has stopped existing looks exactly like a reminder that hasn't come due yet, so without being told, you'd find out when it didn't go off. If you see the "started with none" version, your own reminders need recreating — the system jobs above come back on their own.
 
+Settings → **Scheduling** is where you check the outcome: it lists everything scheduled and repeats the recovery notice above the list itself, because further down the screen a short list of reminders looks exactly like a correct one. See [Settings → Scheduling](../reference/settings.md#scheduling).
+
 The single case where Jenny still refuses to start is when the broken file can't be moved aside at all. Starting anyway would mean the next save overwrites it, and that file is the only copy of your reminders left.
 
 ## Heartbeat: a periodic checklist
@@ -129,6 +131,8 @@ When Heartbeat does decide to speak, the message is delivered proactively to **b
 The practical rule of thumb: **write tasks under `## Active Tasks`, and delete them once they're done.** Every cycle where that section has content triggers one real LLM call — a forgotten task left in the file keeps costing tokens every 30 minutes indefinitely, even if Heartbeat never finds anything worth reporting.
 
 Example of something reasonable to put there: "Check the weather forecast around 7am and warn me if it looks like rain."
+
+**An empty checklist is free, and now it is also visible.** Skipping the cycle costs nothing, but the job still records a normal `ok` on every beat — so from the outside a heartbeat that is checking nothing is indistinguishable from a healthy one, and the only trace was a debug log line. Settings → **Scheduling** says it in words: the tasks it can actually see in `HEARTBEAT.md`, or a notice that there are none. The same panel names a task that has not been carried out for several cycles, and whether Jenny has already told you about it.
 
 **Heartbeat has one schedule for the whole file.** Every line under `## Active Tasks` is looked at on the same 30-minute beat; there's no per-task cadence, and adding a second heartbeat job isn't the way to get one. If a particular check needs its own rhythm — every 10 minutes, or only on weekday mornings — that's a monitor job ([Two modes](#two-modes-one-that-always-speaks-one-that-speaks-only-if-it-has-to) above), which gives you an independent schedule and the same "only speaks if it's worth it" behavior. Heartbeat stays the right home for the shared, ambient checklist.
 

--- a/jenny/agent/tools/cron.py
+++ b/jenny/agent/tools/cron.py
@@ -13,6 +13,7 @@ from jenny.agent.tools.schema import (
     StringSchema,
     tool_parameters_schema,
 )
+from jenny.cron.purposes import system_job_purpose
 from jenny.cron.service import CronService
 from jenny.cron.types import CronJob, CronJobState, CronSchedule
 from jenny.security.workspace_access import (
@@ -395,19 +396,19 @@ class CronTool(Tool, ContextAware):
 
     @staticmethod
     def _system_job_purpose(job: CronJob) -> str:
-        # Un job di sistema che l'utente vede elencato senza sapere cosa fa e
-        # solo un motivo di sospetto: questi girano da soli e spendono token (o
-        # rete), quindi devono sapersi presentare. Chi ne aggiunge un altro lo
-        # aggiunga anche qui.
-        purposes = {
-            "dream": "Dream memory consolidation for long-term memory.",
-            "heartbeat": "Heartbeat: checks HEARTBEAT.md for tasks you left for Jenny.",
-            "update_check": (
-                "Update check: looks for a newer Jenny app release and tells you "
-                "once per version."
-            ),
-        }
-        return purposes.get(job.name, "System-managed internal job.")
+        """La riga con cui un job di sistema si presenta nell'elenco.
+
+        La tabella sta in ``jenny/cron/purposes.py`` e non qui da quando i lettori
+        sono due: questo elenco, che la mostra al modello, e la WebUI, che la
+        mostra all'utente. Due copie divergono, e la prima a divergere e' stata
+        questa — le mancava il giardiniere.
+
+        Per ``id`` e non per ``name``: e' l'id che il container passa a
+        ``register_system_job`` ed e' per id che ``retire_system_job`` toglie. I
+        due coincidono per tutti e quattro i lavoratori, ma il nome e' una
+        stringa che un promemoria dell'utente puo' riusare.
+        """
+        return system_job_purpose(job.id)
 
     def _list_jobs(self) -> str:
         jobs = self._cron.list_jobs()

--- a/jenny/channels/dispatcher.py
+++ b/jenny/channels/dispatcher.py
@@ -54,12 +54,14 @@ class WebSocketDispatcher:
         on_jobs_changed: Callable[[str], None] | None = None,
         ui_query: Any | None = None,
         get_subagent_manager: Callable[[], Any | None] | None = None,
+        get_cron_service: Callable[[], Any | None] | None = None,
     ):
         self.config = config
         self.bus = bus
         self._session_manager = session_manager
         self._snapshot_service = snapshot_service
         self._get_subagent_manager = get_subagent_manager
+        self._get_cron_service = get_cron_service
         self._webui_runtime_model_name = webui_runtime_model_name
         self._onboarding_event = onboarding_event
         self._on_settings_changed = on_settings_changed
@@ -96,6 +98,7 @@ class WebSocketDispatcher:
             runtime_model_name=self._webui_runtime_model_name,
             snapshot_service=self._snapshot_service,
             get_subagent_manager=self._get_subagent_manager,
+            get_cron_service=self._get_cron_service,
             logger=logger,
             onboarding_event=self._onboarding_event,
             on_settings_changed=self._on_settings_changed,

--- a/jenny/cron/purposes.py
+++ b/jenny/cron/purposes.py
@@ -1,0 +1,47 @@
+"""A cosa serve ciascun job di sistema, in una riga che l'utente possa leggere.
+
+Un job di sistema che compare in un elenco senza dire cosa fa è solo un motivo di
+sospetto: questi girano da soli e spendono token o rete, quindi devono sapersi
+presentare. La tabella nasce nel tool ``cron`` e vive qui da quando i lettori sono
+due — il tool, che la mostra al modello, e la WebUI, che la mostra all'utente.
+
+**Chi registra un lavoratore periodico in ``GatewayContainer.build`` gli deve
+anche una riga qui.** Non è una raccomandazione: ``tests/cron/test_system_job_purposes.py``
+confronta questa tabella con gli id che il container registra davvero, e senza la
+riga è rosso. La regola valeva anche prima, scritta in un commento — ed è stata
+persa lo stesso: il giardiniere è stato registrato il giorno che è nato e si è
+presentato come «System-managed internal job.» finché quel test non è esistito.
+
+I job **ritirati** (``_RETIRED_SYSTEM_JOBS``) non stanno qui: il loro job sparisce
+dallo store al primo avvio della versione che li ritira, e nel frattempo cade sul
+fallback, che è esattamente ciò che vogliamo dire di loro.
+"""
+
+from __future__ import annotations
+
+# Chiave: l'``id`` del job (non il nome). Sono la stessa stringa per tutti e
+# quattro, ma è l'id che il container passa a ``register_system_job`` ed è per id
+# che ``retire_system_job`` toglie — il nome un utente può riusarlo per un suo
+# promemoria, l'id no.
+SYSTEM_JOB_PURPOSES: dict[str, str] = {
+    "dream": "Dream memory consolidation for long-term memory.",
+    "gardener": (
+        "Gardener: turns what you told Jenny into pages under the project wikis, "
+        "and promotes what it learns."
+    ),
+    "heartbeat": "Heartbeat: checks HEARTBEAT.md for tasks you left for Jenny.",
+    "update_check": (
+        "Update check: looks for a newer Jenny app release and tells you once per version."
+    ),
+}
+
+# Cosa si dice di un job di sistema che la tabella non conosce. Capita per un job
+# ritirato non ancora spazzato via dallo store, e per un aggiornamento che
+# introduce un lavoratore senza la sua riga — nel secondo caso il test è rosso
+# prima che il telefono lo veda, quindi questo fallback copre soltanto il primo.
+UNKNOWN_SYSTEM_JOB_PURPOSE = "System-managed internal job."
+
+
+def system_job_purpose(job_id: str) -> str:
+    """La riga di presentazione di *job_id*, o il fallback se non la conosciamo."""
+    return SYSTEM_JOB_PURPOSES.get(job_id, UNKNOWN_SYSTEM_JOB_PURPOSE)

--- a/jenny/runtime/container.py
+++ b/jenny/runtime/container.py
@@ -394,6 +394,11 @@ class GatewayContainer:
             # Late-binding come ``get_agent`` per il cron: l'agente può essere
             # creato dopo il gateway (onboarding) e riassegnato da set_agent.
             get_subagent_manager=lambda: getattr(self._agent, "subagents", None),
+            # Il servizio cron esiste gia' quando il gateway parte (lo costruisce
+            # ``build`` piu' sopra), ma resta un getter e non l'oggetto: la WebUI
+            # e' servita anche prima che ``build`` arrivi in fondo, e ``self.cron``
+            # nasce ``None``.
+            get_cron_service=lambda: self.cron,
         )
 
         if self.channels.enabled:

--- a/jenny/templates/ui/assets/i18n/en.json
+++ b/jenny/templates/ui/assets/i18n/en.json
@@ -735,6 +735,84 @@
     "retentionForever": "Forever",
     "retentionDays": "{days} days"
   },
+  "cron": {
+    "sectionTitle": "Scheduling",
+    "asOf": "As of {time}",
+    "refresh": "Refresh",
+    "empty": "Nothing scheduled.",
+    "notStarted": "Scheduling has not started yet: this happens during first-time setup.",
+    "failed": "Cannot read the scheduling status.",
+    "unit": {
+      "second": "{n} second",
+      "seconds": "{n} seconds",
+      "minute": "{n} minute",
+      "minutes": "{n} minutes",
+      "hour": "{n} hour",
+      "hours": "{n} hours",
+      "day": "{n} day",
+      "days": "{n} days"
+    },
+    "schedule": {
+      "every": "every {every}",
+      "expr": "schedule: {expr}",
+      "at": "once, on {when}",
+      "unknown": "schedule not recognised"
+    },
+    "when": {
+      "now": "now",
+      "in": "in {d}",
+      "ago": "{d} ago"
+    },
+    "status": {
+      "ok": "ran",
+      "silenced": "looked, nothing to report",
+      "skipped": "did not start",
+      "could_not_check": "could not check",
+      "error": "error",
+      "unknown": "unknown outcome"
+    },
+    "banner": {
+      "stopped": "The scheduler is stopped: the times below have not been recomputed, and past ones stay in the past.",
+      "inertOne": "{name} is armed but does nothing: your settings have it switched off.",
+      "inertMany": "{names} are armed but do nothing: your settings have them switched off.",
+      "heartbeatEmpty": "The heartbeat runs {every} but HEARTBEAT.md has no active tasks: it is checking nothing.",
+      "recoveredBackup": "This list was rebuilt from the last good backup at startup. Check that everything is here.",
+      "recoveredEmpty": "At startup the list was unreadable and there was no usable backup: the reminders you had created are gone."
+    },
+    "job": {
+      "protected": "system",
+      "monitor": "speaks only if it has something to report",
+      "oneShot": "once only",
+      "disabled": "off",
+      "inert": "does nothing",
+      "next": "Next",
+      "nextOverdue": "Overdue",
+      "last": "Last",
+      "neverRun": "never ran",
+      "noNext": "no next run",
+      "runs": "Recent runs",
+      "noRuns": "No runs recorded.",
+      "detail": "Details",
+      "text": "Reminder text"
+    },
+    "health": {
+      "couldNotCheck": "Could not check {n} times in a row",
+      "since": "since {when}",
+      "warned": "you have been told",
+      "notWarned": "you have not been told yet"
+    },
+    "heartbeat": {
+      "title": "Checks in HEARTBEAT.md",
+      "checkingNothing": "No active tasks: the heartbeat runs and checks nothing.",
+      "fileMissing": "HEARTBEAT.md does not exist yet.",
+      "fileUnreadable": "HEARTBEAT.md is there but cannot be read: check the file permissions.",
+      "taskOk": "fine",
+      "taskBroken": "has not run for {n} cycles",
+      "taskPending": "handed to a subagent, waiting for its verdict",
+      "orphans": "Entries with no task",
+      "orphansHint": "Checks left in the state after their line was removed from HEARTBEAT.md. They explain the counters above and need nothing."
+    }
+  },
   "onboarding": {
     "selectFormat": "Choose your provider format",
     "selectFormatDesc": "Most LLM services speak one of these formats.",

--- a/jenny/templates/ui/assets/i18n/it.json
+++ b/jenny/templates/ui/assets/i18n/it.json
@@ -735,6 +735,84 @@
     "retentionForever": "Per sempre",
     "retentionDays": "{days} giorni"
   },
+  "cron": {
+    "sectionTitle": "Programmazione",
+    "asOf": "Aggiornato alle {time}",
+    "refresh": "Aggiorna",
+    "empty": "Nessuna attività programmata.",
+    "notStarted": "La programmazione non è ancora partita: succede durante la configurazione iniziale.",
+    "failed": "Non riesco a leggere lo stato della programmazione.",
+    "unit": {
+      "second": "{n} secondo",
+      "seconds": "{n} secondi",
+      "minute": "{n} minuto",
+      "minutes": "{n} minuti",
+      "hour": "{n} ora",
+      "hours": "{n} ore",
+      "day": "{n} giorno",
+      "days": "{n} giorni"
+    },
+    "schedule": {
+      "every": "ogni {every}",
+      "expr": "orario: {expr}",
+      "at": "una volta, il {when}",
+      "unknown": "schedulazione non riconosciuta"
+    },
+    "when": {
+      "now": "adesso",
+      "in": "fra {d}",
+      "ago": "{d} fa"
+    },
+    "status": {
+      "ok": "eseguito",
+      "silenced": "ha guardato, niente da dire",
+      "skipped": "non è partito",
+      "could_not_check": "non ha potuto controllare",
+      "error": "errore",
+      "unknown": "esito sconosciuto"
+    },
+    "banner": {
+      "stopped": "Lo scheduler è fermo: le scadenze qui sotto non sono state rimesse, e quelle passate restano nel passato.",
+      "inertOne": "{name} è armato ma non fa niente: la configurazione lo dice spento.",
+      "inertMany": "{names} sono armati ma non fanno niente: la configurazione li dice spenti.",
+      "heartbeatEmpty": "L'heartbeat gira {every} ma HEARTBEAT.md non ha task attivi: non sta controllando niente.",
+      "recoveredBackup": "Questo elenco è stato ricostruito dall'ultimo backup valido all'avvio. Controlla che ci siano tutti.",
+      "recoveredEmpty": "All'avvio l'elenco non era leggibile e non c'era un backup utilizzabile: i promemoria che avevi creato non ci sono più."
+    },
+    "job": {
+      "protected": "di sistema",
+      "monitor": "parla solo se ha qualcosa da dire",
+      "oneShot": "una volta sola",
+      "disabled": "spento",
+      "inert": "non fa niente",
+      "next": "Prossima",
+      "nextOverdue": "In ritardo",
+      "last": "Ultima",
+      "neverRun": "mai eseguito",
+      "noNext": "nessuna scadenza",
+      "runs": "Ultime esecuzioni",
+      "noRuns": "Nessuna esecuzione registrata.",
+      "detail": "Dettagli",
+      "text": "Testo del promemoria"
+    },
+    "health": {
+      "couldNotCheck": "Non ha potuto controllare {n} volte di fila",
+      "since": "da {when}",
+      "warned": "te l'ha già detto",
+      "notWarned": "non te l'ha ancora detto"
+    },
+    "heartbeat": {
+      "title": "Controlli in HEARTBEAT.md",
+      "checkingNothing": "Nessun task attivo: l'heartbeat gira e non controlla niente.",
+      "fileMissing": "HEARTBEAT.md non esiste ancora.",
+      "fileUnreadable": "HEARTBEAT.md c'è ma non si legge: controlla i permessi del file.",
+      "taskOk": "regolare",
+      "taskBroken": "non parte da {n} giri",
+      "taskPending": "affidato a un subagent, in attesa del verdetto",
+      "orphans": "Voci senza task",
+      "orphansHint": "Controlli rimasti nello stato dopo che la riga è stata tolta da HEARTBEAT.md. Spiegano i contatori qui sopra e non richiedono niente."
+    }
+  },
   "onboarding": {
     "selectFormat": "Scegli il formato del provider",
     "selectFormatDesc": "La maggior parte dei servizi LLM usa uno di questi formati.",

--- a/jenny/templates/ui/assets/mobile-settings.js
+++ b/jenny/templates/ui/assets/mobile-settings.js
@@ -16,6 +16,7 @@ import {
   batteryExemptionSupported,
   batteryExemptionNeeded,
 } from './shared/battery-exemption.js';
+import { buildCronView } from './shared/cron-view.js';
 import {
   runExportFlow,
   runImportFlow,
@@ -152,6 +153,12 @@ export class SettingsController {
     // sezione che non è più a schermo.
     clearTimeout(this._updateTimer);
     this._updateTimer = null;
+    /* L'apertura d'ufficio della sezione Programmazione vale una volta per
+       apertura di schermata: senza questo azzeramento, chi la chiude a mano e
+       torna dopo non la vedrebbe riaprirsi nemmeno con un guasto nuovo — e
+       riaprirla a ogni `render()` (cioè a ogni salvataggio) sarebbe una lotta
+       con l'utente. */
+    this._cronAutoOpened = false;
   }
 
   /* Sotto-stato della sezione: il catalogo modelli aperto occupa la vista e per
@@ -186,6 +193,7 @@ export class SettingsController {
       this._section('tools', 'ti-tool', i18n.t('settings.tools'), this._renderTools(d)),
       this._section('memory', 'ti-sparkles', i18n.t('settings.memory.title'), this._renderMemory(d)),
       this._section('workers', 'ti-map', i18n.t('settings.workers.title'), this._renderWorkers(d)),
+      this._section('scheduling', 'ti-alarm', i18n.t('cron.sectionTitle'), this._renderScheduling()),
       this._renderBatterySection(d),
       this._section('ssh', 'ti-terminal-2', i18n.t('settings.ssh.title'), this._renderSsh()),
       this._section('telegram', 'ti-brand-telegram', i18n.t('settings.telegram.title'), this._renderTelegram()),
@@ -2130,6 +2138,265 @@ export class SettingsController {
 
   // ── Wire Events ────────────────────────────────────────────────────
 
+  // ── Programmazione ─────────────────────────────────────────────────────
+
+  /* Segnaposto: il blocco si popola da `_loadCron`, come SSH e gli snapshot.
+     Renderlo sincrono vorrebbe dire una fetch dentro `render()`, e `render()`
+     gira anche dopo ogni salvataggio. */
+  _renderScheduling() {
+    return `<div id="cron-block"><div class="settings-empty-state">${i18n.t('settings.loading')}</div></div>`;
+  }
+
+  /* Una sola lettura, all'apertura della schermata e sul pulsante Aggiorna.
+
+     **Nessun polling**, ed è una decisione e non una semplificazione: su questo
+     telefono il lavoro anti-doze si misura in job puntuali a ±2 s attraverso ore
+     di doze profondo, e un pannello che sveglia gateway e WebView ogni cinque
+     secondi finché è aperto è esattamente il contrario. Il timbro «aggiornato
+     alle …» in cima dichiara che è un'istantanea, così l'utente non deve
+     chiedersi se sta guardando il presente. */
+  async _loadCron() {
+    const gen = this._gen;
+    if (!this.contentEl.querySelector('#cron-block')) return;
+    let payload;
+    try {
+      payload = await api.getCron();
+    } catch {
+      if (this._stale(gen)) return;
+      const failEl = this.contentEl.querySelector('#cron-block');
+      if (failEl) {
+        failEl.innerHTML = `<div class="settings-empty-state">${i18n.t('cron.failed')}</div>`;
+      }
+      return;
+    }
+    if (this._stale(gen)) return;
+    // Il nodo si cerca **dopo** l'await: `render()` rifà tutto l'innerHTML, e un
+    // `#cron-block` catturato prima della fetch è già staccato dal documento.
+    const blockEl = this.contentEl.querySelector('#cron-block');
+    if (!blockEl) return;
+    this._cron = buildCronView(payload, {
+      nowMs: payload.now_ms,
+      tr: (key, params) => i18n.t(key, params),
+      locale: i18n.locale,
+    });
+    blockEl.innerHTML = this._renderCronBlock(this._cron);
+    this._wireCronBlock();
+    /* Se c'è qualcosa da dire, la sezione si apre da sé. Stesso argomento della
+       card batteria: un accordion chiuso è esattamente il posto in cui il
+       problema è rimasto invisibile finora. Solo la prima volta per apertura di
+       schermata, perché richiudere una sezione che l'utente ha chiuso a mano
+       sarebbe una lotta. */
+    if (this._cron.banner && !this._cronAutoOpened) {
+      this._cronAutoOpened = true;
+      this._openSections.add('scheduling');
+      const sec = this.contentEl.querySelector('[data-section="scheduling"]');
+      if (sec) sec.classList.remove('collapsed');
+    }
+    this._restoreScrollTop();
+  }
+
+  _renderCronBlock(view) {
+    if (!view.available) {
+      return `<div class="settings-empty-state">${i18n.t('cron.notStarted')}</div>`;
+    }
+    const stamp = new Date(view.asOf).toLocaleTimeString(i18n.locale, {
+      hour: '2-digit', minute: '2-digit',
+    });
+    const rows = view.rows.length
+      ? view.rows.map(r => this._renderCronJob(r)).join('')
+      : `<div class="settings-empty-state">${i18n.t('cron.empty')}</div>`;
+    return `
+      ${this._renderCronBanner(view)}
+      ${rows}
+      <div class="cron-asof">
+        <span>${escapeHtml(i18n.t('cron.asOf', { time: stamp }))}</span>
+        <button class="cron-refresh" id="btn-cron-refresh">
+          <i class="ti ti-refresh"></i> ${i18n.t('cron.refresh')}
+        </button>
+      </div>`;
+  }
+
+  /* Un banner solo, il più utile: la scelta sta in `pickBanner` (modulo puro),
+     qui c'è soltanto il testo. Il caso `inert` cerca prima di tutto l'heartbeat,
+     perché per lui la frase può dire *cosa* manca — un file senza task — mentre
+     per gli altri tre può solo dire che l'interruttore è giù. */
+  _renderCronBanner(view) {
+    const b = view.banner;
+    if (!b) return '';
+    let text = '';
+    let strong = false;
+    if (b.kind === 'stopped') {
+      text = i18n.t('cron.banner.stopped');
+      strong = true;
+    } else if (b.kind === 'recovered') {
+      const empty = b.restoredFrom === 'empty';
+      text = i18n.t(empty ? 'cron.banner.recoveredEmpty' : 'cron.banner.recoveredBackup');
+      strong = empty;
+    } else if (b.kind === 'inert') {
+      const hb = view.rows.find(r => r.id === 'heartbeat' && r.heartbeat?.checkingNothing);
+      if (hb) {
+        text = i18n.t('cron.banner.heartbeatEmpty', { every: hb.schedule });
+      } else if (b.jobs.length === 1) {
+        text = i18n.t('cron.banner.inertOne', { name: b.jobs[0] });
+      } else {
+        text = i18n.t('cron.banner.inertMany', { names: b.jobs.join(', ') });
+      }
+    } else {
+      return '';
+    }
+    return `<div class="settings-notice${strong ? ' settings-notice-strong' : ''}">
+      <i class="ti ti-alert-triangle"></i>
+      <div>${escapeHtml(text)}</div>
+    </div>`;
+  }
+
+  /* Una card per job. In chiaro ci sta quel che si legge di sfuggita — nome,
+     schedulazione, prossima e ultima esecuzione — e il resto (storico, testo del
+     promemoria, controlli dell'heartbeat) sta nel dettaglio: una riga d'elenco
+     che porta tutto smette di essere un elenco. */
+  _renderCronJob(row) {
+    const badges = [];
+    if (row.kind === 'system') badges.push(i18n.t('cron.job.protected'));
+    if (row.monitor) badges.push(i18n.t('cron.job.monitor'));
+    if (row.oneShot) badges.push(i18n.t('cron.job.oneShot'));
+    if (row.health === 'off') badges.push(i18n.t('cron.job.disabled'));
+    if (row.health === 'inert') badges.push(i18n.t('cron.job.inert'));
+    const badgeHtml = badges.length
+      ? `<div class="cron-badges">${badges.map(b => `<span class="cron-badge">${escapeHtml(b)}</span>`).join('')}</div>`
+      : '';
+    const next = row.next
+      ? `<span class="cron-when${row.next.overdue ? ' cron-when-overdue' : ''}">
+           ${escapeHtml(row.next.overdue ? i18n.t('cron.job.nextOverdue') : i18n.t('cron.job.next'))}:
+           ${escapeHtml(row.next.relative)}${this._cronTz(row.next)}
+         </span>`
+      : `<span class="cron-when cron-when-muted">${escapeHtml(i18n.t('cron.job.noNext'))}</span>`;
+    const last = row.last
+      ? `<span class="cron-when">
+           ${escapeHtml(i18n.t('cron.job.last'))}: ${escapeHtml(row.last.relative)}
+           <span class="cron-dot cron-dot-${row.lastTone}"></span>${escapeHtml(this._cronStatusText(row.lastStatus))}
+         </span>`
+      : `<span class="cron-when cron-when-muted">${escapeHtml(i18n.t('cron.job.neverRun'))}</span>`;
+    const cnc = row.couldNotCheck?.consecutive_could_not_check
+      ? `<div class="cron-health">${escapeHtml(this._cronHealthText(row.couldNotCheck))}</div>`
+      : '';
+    return `
+      <div class="cron-card cron-card-${row.health}" data-cron-job="${escapeHtml(row.id)}">
+        <div class="cron-card-head">
+          <span class="cron-name">${escapeHtml(row.name)}</span>
+          <span class="cron-schedule">${escapeHtml(row.schedule)}</span>
+        </div>
+        ${badgeHtml}
+        <div class="cron-lines">${next}${last}</div>
+        ${cnc}
+      </div>`;
+  }
+
+  /* Il fuso si nomina solo quando diverge da quello del dispositivo: `09:00
+     (Asia/Tokyo)` è utile, `(Europe/Rome)` su un telefono a Roma è rumore su
+     ogni riga. La decisione sta in `timeZoneNote`. */
+  _cronTz(when) {
+    return when.timeZoneNote ? ` <span class="cron-tz">(${escapeHtml(when.timeZoneNote)})</span>` : '';
+  }
+
+  _cronStatusText(status) {
+    const text = i18n.t(`cron.status.${status}`);
+    // `i18n.t` ritorna la chiave grezza quando non la conosce: uno store scritto
+    // da una versione più nuova non deve stampare "cron.status.qualcosa".
+    return text.startsWith('cron.status.') ? i18n.t('cron.status.unknown') : text;
+  }
+
+  _cronHealthText(health) {
+    const parts = [i18n.t('cron.health.couldNotCheck', { n: health.consecutive_could_not_check })];
+    if (health.since_ms) {
+      parts.push(i18n.t('cron.health.since', {
+        when: new Date(health.since_ms).toLocaleString(i18n.locale),
+      }));
+    }
+    parts.push(i18n.t(health.escalated ? 'cron.health.warned' : 'cron.health.notWarned'));
+    return parts.join(' · ');
+  }
+
+  _wireCronBlock() {
+    this._wireBtn('btn-cron-refresh', () => this._loadCron());
+    this.contentEl.querySelectorAll('[data-cron-job]').forEach(card => {
+      card.addEventListener('click', () => {
+        const row = this._cron?.rows.find(r => r.id === card.dataset.cronJob);
+        if (row) this._showCronJobDialog(row);
+      });
+    });
+  }
+
+  /* Il dettaglio è **piatto**: storico e controlli dell'heartbeat stanno dentro
+     la stessa modale. `detailDialog` ha una sola istanza (`#oc-detail-dialog`) e
+     si rifiuta di aprirsi se è già aperta, quindi un secondo livello job→run non
+     esisterebbe comunque — meglio progettarlo piatto che scoprirlo dopo. */
+  _showCronJobDialog(row) {
+    const parts = [];
+    if (row.purpose) parts.push(`<p class="oc-detail-lead">${escapeHtml(row.purpose)}</p>`);
+    if (row.message) {
+      parts.push(`<div class="settings-subheading">${i18n.t('cron.job.text')}</div>
+        <p class="cron-detail-text">${escapeHtml(row.message)}</p>`);
+    }
+    if (row.heartbeat) parts.push(this._renderCronHeartbeat(row.heartbeat));
+    parts.push(`<div class="settings-subheading">${i18n.t('cron.job.runs')}</div>`);
+    if (row.runs.length) {
+      parts.push(`<div class="cron-runs">${row.runs.map(run => `
+        <div class="cron-run">
+          <span class="cron-dot cron-dot-${run.tone}"></span>
+          <span class="cron-run-when">${escapeHtml(new Date(run.atMs).toLocaleString(i18n.locale))}</span>
+          <span class="cron-run-status">${escapeHtml(this._cronStatusText(run.status))}</span>
+          ${run.error ? `<span class="cron-run-error">${escapeHtml(run.error)}</span>` : ''}
+        </div>`).join('')}</div>`);
+    } else {
+      parts.push(`<div class="settings-empty-state">${i18n.t('cron.job.noRuns')}</div>`);
+    }
+    detailDialog({ title: row.name, bodyHtml: parts.join('') });
+  }
+
+  /* I controlli di HEARTBEAT.md. Il blocco esiste solo per il job `heartbeat`, e
+     dice due cose che lo store da solo non sa dire: quali controlli **esistono**
+     (il file), e quali di quelli sono rotti (lo stato). Senza la prima metà, un
+     heartbeat che gira a vuoto è indistinguibile da uno sano — registra `ok` a
+     ogni giro. */
+  _renderCronHeartbeat(hb) {
+    const head = `<div class="settings-subheading">${i18n.t('cron.heartbeat.title')}</div>`;
+    if (!hb.fileReadable) {
+      return `${head}<div class="settings-notice settings-notice-strong">
+        <i class="ti ti-alert-triangle"></i>
+        <div>${escapeHtml(i18n.t('cron.heartbeat.fileUnreadable'))}</div></div>`;
+    }
+    if (!hb.filePresent) {
+      return `${head}<div class="settings-empty-state">${i18n.t('cron.heartbeat.fileMissing')}</div>`;
+    }
+    if (hb.checkingNothing) {
+      return `${head}<div class="settings-notice settings-notice-strong">
+        <i class="ti ti-alert-triangle"></i>
+        <div>${escapeHtml(i18n.t('cron.heartbeat.checkingNothing'))}</div></div>`;
+    }
+    const tasks = hb.tasks.map(t => {
+      let note;
+      if (t.state === 'broken') note = i18n.t('cron.heartbeat.taskBroken', { n: t.consecutive });
+      else if (t.state === 'pending') note = i18n.t('cron.heartbeat.taskPending');
+      else note = i18n.t('cron.heartbeat.taskOk');
+      const warned = t.state === 'broken'
+        ? ` · ${i18n.t(t.escalated ? 'cron.health.warned' : 'cron.health.notWarned')}`
+        : '';
+      return `<div class="cron-task cron-task-${t.state}">
+        <span class="cron-task-label">${escapeHtml(t.label || String(t.index))}</span>
+        <span class="cron-task-note">${escapeHtml(note + warned)}</span>
+      </div>`;
+    }).join('');
+    const orphans = hb.orphans.length
+      ? `<div class="settings-subheading">${i18n.t('cron.heartbeat.orphans')}</div>
+         <p class="settings-field-hint">${escapeHtml(i18n.t('cron.heartbeat.orphansHint'))}</p>
+         ${hb.orphans.map(o => `<div class="cron-task cron-task-orphan">
+            <span class="cron-task-label">${escapeHtml(o.label || o.id)}</span>
+            <span class="cron-task-note">${escapeHtml(i18n.t('cron.heartbeat.taskBroken', { n: o.consecutive }))}</span>
+          </div>`).join('')}`
+      : '';
+    return `${head}<div class="cron-tasks">${tasks}</div>${orphans}`;
+  }
+
   _wireSections() {
     // Accordion toggle (lo stato aperto va in _openSections così i
     // re-render non richiudono la sezione in cui l'utente sta lavorando)
@@ -2265,6 +2532,9 @@ export class SettingsController {
 
     // SSH: il blocco si popola da solo (chiamata a parte, v. _renderSsh)
     this._loadSsh();
+
+    // Programmazione: stessa forma, un segnaposto e un caricatore
+    this._loadCron();
 
     // Backup e ripristino
     this._wireBackup();

--- a/jenny/templates/ui/assets/mobile-style.css
+++ b/jenny/templates/ui/assets/mobile-style.css
@@ -6979,3 +6979,182 @@ body {
 }
 .tg-disabled .ti-circle-off { font-size: 20px; }
 .tg-bot-link { color: var(--accent); font-weight: 600; }
+
+/* ── Programmazione (sezione impostazioni) ─────────────────────────────────
+   Una card per job. Il bordo sinistro porta il verdetto — rotto, inerte,
+   spento, sano — perché è la cosa che si cerca scorrendo, e i pallini portano
+   l'esito dei singoli run. Nessun colore su `silenced`: un monitor che tace ha
+   funzionato, e colorarlo insegnerebbe a ignorare i colori. */
+.cron-card {
+  padding: 11px 12px;
+  margin-bottom: 8px;
+  border: 0.5px solid var(--border);
+  border-left: 3px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+}
+
+.cron-card:active { background: var(--active); }
+.cron-card-broken { border-left-color: var(--warning); }
+.cron-card-inert { border-left-color: var(--warning); }
+.cron-card-off { border-left-color: var(--border); opacity: 0.62; }
+
+.cron-card-head {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.cron-name {
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--heading);
+}
+
+.cron-schedule {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.cron-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.cron-badge {
+  padding: 1px 7px;
+  border: 0.5px solid var(--border);
+  border-radius: var(--radius-pill);
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+/* Le due righe di tempo vanno in colonna e non affiancate: «fra 28 minuti» e
+   «2 ore fa · ha guardato, niente da dire» hanno lunghezze molto diverse, e su
+   380 px affiancarle manderebbe la seconda a capo in mezzo a una parola. */
+.cron-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 7px;
+}
+
+.cron-when {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.cron-when-muted { color: var(--text-faint); }
+.cron-when-overdue { color: var(--warning); font-weight: 600; }
+.cron-tz { color: var(--text-faint); }
+
+.cron-health {
+  margin-top: 6px;
+  font-size: 11.5px;
+  color: var(--warning);
+  line-height: 1.4;
+}
+
+.cron-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin: 0 5px 0 7px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  vertical-align: middle;
+}
+
+.cron-dot-ok { background: var(--ok); }
+.cron-dot-warn { background: var(--warning); }
+.cron-dot-bad { background: var(--error); }
+/* `neutral` resta il grigio del default: v. la nota in testa al blocco. */
+
+.cron-asof {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--text-faint);
+}
+
+.cron-refresh {
+  padding: 4px 10px;
+  border: 0.5px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-family: inherit;
+}
+
+.cron-refresh:active { background: var(--active); }
+
+/* ── dettaglio del job ─────────────────────────────────────────────────── */
+.cron-detail-text {
+  margin: 0 0 12px;
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.cron-runs { display: flex; flex-direction: column; gap: 3px; }
+
+.cron-run {
+  display: flex;
+  gap: 4px;
+  align-items: baseline;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.cron-run-when {
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.cron-run-error {
+  color: var(--error);
+  overflow-wrap: anywhere;
+}
+
+.cron-tasks { display: flex; flex-direction: column; gap: 5px; }
+
+.cron-task {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 7px 9px;
+  border-left: 2px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.cron-task-broken { border-left-color: var(--warning); }
+.cron-task-pending { border-left-color: var(--accent); }
+.cron-task-orphan { border-left-color: var(--border); opacity: 0.7; }
+
+.cron-task-label {
+  font-size: 12.5px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.cron-task-note {
+  font-size: 11px;
+  color: var(--text-muted);
+}

--- a/jenny/templates/ui/assets/shared/api-client.js
+++ b/jenny/templates/ui/assets/shared/api-client.js
@@ -129,6 +129,15 @@ class ApiClient {
     return res.json();
   }
 
+  /** Stato della programmazione: cosa e' armato, e cosa fa davvero.
+   *  Sola lettura — le scritture passano dal tool `cron`, che e' l'unico imbuto
+   *  sullo store dei job. */
+  async getCron() {
+    const res = await this._fetch('/api/webui/cron');
+    if (!res.ok) throw new Error(`Cron failed: ${res.status}`);
+    return res.json();
+  }
+
   async getAndroidApps() {
     const res = await this._fetch('/api/webui/android-apps');
     if (!res.ok) throw new Error(`Android apps failed: ${res.status}`);

--- a/jenny/templates/ui/assets/shared/cron-view.js
+++ b/jenny/templates/ui/assets/shared/cron-view.js
@@ -1,0 +1,277 @@
+/** Il modello di vista della sezione «Programmazione»: dal payload alle righe.
+ *
+ *  Modulo puro **di proposito**: niente DOM, niente `window`, niente i18n
+ *  importato — la traduzione arriva come funzione `tr` dal chiamante. Sta in
+ *  `shared/` per la stessa ragione di `launcher-rank.js`: è l'unica parte del
+ *  pannello che si può provare senza un telefono, e i casi che deve azzeccare
+ *  sono precisamente quelli che sul telefono non si riesce a fabbricare — un
+ *  worker spento, uno scheduler fermo, una scadenza nel passato.
+ *
+ *  Tre regole di vocabolario che il pannello non deve reinventare, perché il
+ *  servizio le ha già decise (v. `jenny/cron/types.py`):
+ *
+ *  1. `silenced` **non è un fallimento**: è un monitor che ha guardato e non
+ *     aveva niente da dire. Colorarlo di rosso insegna a ignorare i colori.
+ *  2. `could_not_check` **non è un `error`**: è il terzo stato, «ha girato ma il
+ *     controllo non è avvenuto». Confonderli cancella la distinzione per cui
+ *     quello stato esiste — un monitor rotto sembrava un giardino sano.
+ *  3. `skipped` non è né l'uno né l'altro: non è partito, e va detto senza
+ *     allarme.
+ */
+
+/* Come si rende ciascuno dei cinque esiti. `tone` è la sola cosa che il CSS
+   guarda; il testo passa da `tr`. */
+const STATUS_TONE = {
+  ok: 'ok',
+  silenced: 'neutral',
+  skipped: 'neutral',
+  could_not_check: 'warn',
+  error: 'bad',
+};
+
+/* Sotto questa distanza si dice «adesso» invece di «fra 0 minuti». */
+const NOW_WINDOW_MS = 45_000;
+
+const MINUTE = 60_000;
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+/** Il tono di un esito, o `neutral` per un esito che questa versione non conosce.
+ *
+ *  Il default è `neutral` e non `bad`: uno store scritto da una versione più
+ *  nuova può portare un valore che qui non c'è, e trattare l'ignoto come un
+ *  guasto è il modo di far sembrare rotto un aggiornamento riuscito. */
+export function statusTone(status) {
+  return STATUS_TONE[status] ?? 'neutral';
+}
+
+/** Un job è rotto, inerte, spento o sano — in quest'ordine di precedenza.
+ *
+ *  `broken` prima di `inert` perché un worker che ha una sequenza di controlli
+ *  mancati sta dicendo qualcosa di più urgente di «la config ti ha spento», e
+ *  `inert` prima di `off` perché un job spento dall'utente non è una notizia. */
+export function jobHealth(job) {
+  if (job?.health?.consecutive_could_not_check > 0) return 'broken';
+  if (job?.effective === 'inert') return 'inert';
+  if (job?.effective === 'disabled' || job?.enabled === false) return 'off';
+  return 'ok';
+}
+
+/* Ordine di lettura: prima quel che chiede attenzione, poi il prossimo a
+   suonare. Un `next_run_at_ms` assente vale `Infinity` — la stessa convenzione
+   di `CronService.list_jobs` — così un job senza scadenza finisce in fondo
+   invece che in cima. */
+const HEALTH_RANK = { broken: 0, inert: 1, ok: 2, off: 3 };
+
+export function compareJobs(a, b) {
+  const rank = HEALTH_RANK[jobHealth(a)] - HEALTH_RANK[jobHealth(b)];
+  if (rank !== 0) return rank;
+  const an = a?.next_run_at_ms ?? Infinity;
+  const bn = b?.next_run_at_ms ?? Infinity;
+  if (an !== bn) return an - bn;
+  return String(a?.name ?? '').localeCompare(String(b?.name ?? ''));
+}
+
+/** Una durata in una frase breve: «30 minuti», «2 ore», «3 giorni».
+ *
+ *  Non usa `Intl.RelativeTimeFormat` perché serve anche senza segno (per
+ *  «ogni N»), e avere due strade per la stessa unità le farebbe divergere. */
+export function humanizeDuration(ms, { tr, locale } = {}) {
+  const total = Math.abs(Math.round(ms));
+  if (total < MINUTE) {
+    return unit(tr, locale, 'second', Math.max(1, Math.round(total / 1000)));
+  }
+  if (total < HOUR) return unit(tr, locale, 'minute', Math.round(total / MINUTE));
+  if (total < DAY) return unit(tr, locale, 'hour', round1(total / HOUR));
+  return unit(tr, locale, 'day', round1(total / DAY));
+}
+
+/* Mezz'ora di scarto su «ogni 2 ore» sparirebbe arrotondando all'intero, e
+   «ogni 2 ore» invece di «ogni 2 ore e mezza» e' una schedulazione diversa: un
+   decimale si mostra solo quando cambia la frase. */
+function round1(value) {
+  return Number.isInteger(value) ? value : Math.round(value * 10) / 10;
+}
+
+/* Singolare e plurale sono **due chiavi**, scelte qui.
+   ``i18n.t`` non sa pluralizzare — interpola ``{n}`` e basta — e «1 minuti» in
+   italiano e' sbagliato in un punto che si legge a ogni riga. La scelta sta nel
+   modulo puro, cosi' e' provabile senza un telefono; il file i18n porta le due
+   forme e non un'euristica. */
+function unit(tr, locale, name, n) {
+  // Il numero passa da ``Intl.NumberFormat``: interpolarlo grezzo scriveva
+  // «1.9 ore fa» su un telefono in italiano — visto sul dispositivo il
+  // 10/09/2026. Cambia una virgola, e cambia su ogni riga che porta un'ora e
+  // mezza.
+  let text;
+  try {
+    text = new Intl.NumberFormat(locale).format(n);
+  } catch {
+    text = String(n);
+  }
+  // La scelta singolare/plurale resta sul **numero**, non sulla stringa
+  // formattata: «1,0» non e' `1`, e un confronto sul testo si romperebbe nella
+  // prima lingua che formatta diversamente.
+  return tr(`cron.unit.${name}${n === 1 ? '' : 's'}`, { n: text });
+}
+
+/** La schedulazione in una frase, dalla struttura e non da una stringa inglese.
+ *
+ *  Il server manda `{kind, every_ms, expr, at_ms, tz}` proprio perché questa
+ *  frase la deve comporre chi conosce la lingua dell'utente. Il tool `cron`
+ *  compone la sua, in inglese, per il modello: sono due lettori diversi. */
+export function describeSchedule(schedule, { tr, locale, timeZone } = {}) {
+  const kind = schedule?.kind;
+  if (kind === 'every' && schedule.every_ms) {
+    return tr('cron.schedule.every', {
+      every: humanizeDuration(schedule.every_ms, { tr, locale }),
+    });
+  }
+  if (kind === 'cron' && schedule.expr) {
+    return tr('cron.schedule.expr', { expr: schedule.expr });
+  }
+  if (kind === 'at' && schedule.at_ms) {
+    return tr('cron.schedule.at', {
+      when: formatAbsolute(schedule.at_ms, { locale, timeZone }),
+    });
+  }
+  return tr('cron.schedule.unknown');
+}
+
+/** Data e ora nel fuso **del job**, non in quello del dispositivo.
+ *
+ *  È la metà che fa sì che il pannello e la chat dicano la stessa ora: il tool
+ *  `cron` formatta con `schedule.tz or default_timezone`, e questo fa lo stesso
+ *  col `display_timezone` che il payload porta per ogni job.
+ *
+ *  Un `timeZone` che `Intl` rifiuta non deve portarsi via la riga: si ricade sul
+ *  fuso del dispositivo. Capita con uno store scritto a mano, o su una
+ *  piattaforma senza il database dei fusi. */
+export function formatAbsolute(ms, { locale, timeZone } = {}) {
+  if (!Number.isFinite(ms)) return '';
+  const date = new Date(ms);
+  const opts = { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' };
+  try {
+    return new Intl.DateTimeFormat(locale, timeZone ? { ...opts, timeZone } : opts).format(date);
+  } catch {
+    return new Intl.DateTimeFormat(locale, opts).format(date);
+  }
+}
+
+/** Il fuso va nominato **solo quando dice qualcosa**, cioè quando diverge da
+ *  quello del dispositivo: `09:00 (Asia/Tokyo)` è utile, `09:00 (Europe/Rome)`
+ *  su un telefono a Roma è rumore su ogni riga. */
+export function timeZoneNote(timeZone) {
+  if (!timeZone) return null;
+  let local = null;
+  try {
+    local = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    local = null;
+  }
+  return local && local === timeZone ? null : timeZone;
+}
+
+/** Quando succede (o è successo), con il verdetto «in ritardo».
+ *
+ *  `overdue` è il punto di questa funzione. `next_run_at_ms` è **persistito**:
+ *  lo ricalcolano l'avvio del servizio e la fine di ogni run, quindi con il
+ *  servizio fermo — o col processo appena riesumato dopo ore di doze — il valore
+ *  nello store è nel passato. Un pannello che lo formattasse e basta scriverebbe
+ *  «prossima esecuzione: ieri alle 22:30» e sembrerebbe rotto lui. */
+export function formatWhen(ms, { nowMs, tr, locale, timeZone } = {}) {
+  if (!Number.isFinite(ms)) return null;
+  const delta = ms - nowMs;
+  const overdue = delta < -NOW_WINDOW_MS;
+  let relative;
+  if (Math.abs(delta) <= NOW_WINDOW_MS) relative = tr('cron.when.now');
+  else if (delta > 0) {
+    relative = tr('cron.when.in', { d: humanizeDuration(delta, { tr, locale }) });
+  } else {
+    relative = tr('cron.when.ago', { d: humanizeDuration(-delta, { tr, locale }) });
+  }
+  return {
+    absolute: formatAbsolute(ms, { locale, timeZone }),
+    relative,
+    overdue,
+    timeZoneNote: timeZoneNote(timeZone),
+  };
+}
+
+/** Il banner in cima, o `null`. Uno solo: il più importante.
+ *
+ *  L'ordine è quello dell'utilità, non della gravità astratta. Uno scheduler
+ *  fermo spiega da solo ogni «in ritardo» della lista, quindi viene prima: senza
+ *  di lui la stessa spiegazione andrebbe ripetuta su ogni riga. */
+export function pickBanner(payload) {
+  if (!payload || payload.available === false) return { kind: 'unavailable' };
+  if (payload.recovery) {
+    return { kind: 'recovered', restoredFrom: payload.recovery.restored_from };
+  }
+  if (payload.service_running === false) return { kind: 'stopped' };
+  const inert = (payload.jobs ?? []).filter((j) => j.effective === 'inert');
+  if (inert.length) return { kind: 'inert', jobs: inert.map((j) => j.name) };
+  return null;
+}
+
+/** I task dell'heartbeat, divisi per quel che chiedono a chi legge.
+ *
+ *  `checkingNothing` è il caso che questo pannello esiste per dire: il job gira,
+ *  registra `ok` a ogni run, e non c'è niente da controllare. Lo store da solo
+ *  lo renderebbe come salute perfetta. */
+export function heartbeatView(block) {
+  if (!block) return null;
+  const tasks = block.tasks ?? [];
+  return {
+    filePresent: block.file_present,
+    fileReadable: block.file_readable,
+    checkingNothing: block.active_task_count === 0,
+    counts: {
+      total: tasks.length,
+      broken: tasks.filter((t) => t.state === 'broken').length,
+      pending: tasks.filter((t) => t.state === 'pending').length,
+    },
+    tasks,
+    orphans: block.orphan_checks ?? [],
+  };
+}
+
+/** Il modello di vista completo. Una chiamata, tutto quel che la sezione rende. */
+export function buildCronView(payload, { nowMs, tr, locale } = {}) {
+  const stamp = Number.isFinite(nowMs) ? nowMs : payload?.now_ms;
+  const banner = pickBanner(payload);
+  if (!payload || payload.available === false) {
+    return { available: false, banner, rows: [], counts: null, asOf: stamp };
+  }
+  const rows = [...(payload.jobs ?? [])].sort(compareJobs).map((job) => {
+    const tz = job.display_timezone || payload.default_timezone;
+    return {
+      id: job.id,
+      name: job.name,
+      kind: job.kind,
+      purpose: job.purpose,
+      protected: job.protected,
+      health: jobHealth(job),
+      monitor: job.mode === 'monitor',
+      oneShot: job.one_shot,
+      messagePreview: job.message_preview,
+      message: job.message,
+      schedule: describeSchedule(job.schedule, { tr, locale, timeZone: tz }),
+      next: formatWhen(job.next_run_at_ms, { nowMs: stamp, tr, locale, timeZone: tz }),
+      last: formatWhen(job.last_run_at_ms, { nowMs: stamp, tr, locale, timeZone: tz }),
+      lastStatus: job.last_status,
+      lastTone: statusTone(job.last_status),
+      lastError: job.last_error,
+      couldNotCheck: job.health,
+      runs: (job.runs ?? []).map((run) => ({
+        atMs: run.run_at_ms,
+        status: run.status,
+        tone: statusTone(run.status),
+        durationMs: run.duration_ms,
+        error: run.error,
+      })),
+      heartbeat: heartbeatView(job.heartbeat),
+    };
+  });
+  return { available: true, banner, rows, counts: payload.counts ?? null, asOf: stamp };
+}

--- a/jenny/utils/android_assets.py
+++ b/jenny/utils/android_assets.py
@@ -252,6 +252,7 @@ _UI_MANIFEST = [
     "assets/shared/backup-flow.js",
     "assets/shared/battery-exemption.js",
     "assets/shared/commands-chip.js",
+    "assets/shared/cron-view.js",
     "assets/shared/dialog.js",
     "assets/shared/home-view.js",
     "assets/shared/i18n.js",

--- a/jenny/webui/cron_api.py
+++ b/jenny/webui/cron_api.py
@@ -1,0 +1,330 @@
+"""Payload della WebUI per la programmazione: cosa e' armato, e cosa fa davvero.
+
+Neutro rispetto al trasporto, come ``skills_api``: costruisce un dizionario e non
+sa niente di HTTP. La route che lo serve sta in ``webui/cron_routes.py``.
+
+**Sincrona e con I/O: il chiamante la mette in un thread.** Legge lo store del
+cron (sotto il lock del file, lo stesso che prende un ``add_job`` del tool), la
+config da disco e ``HEARTBEAT.md``. Sul loop del gateway quel lock bloccherebbe
+la chat e la WebSocket.
+
+Il pannello non rende lo store: lo **riconcilia**. Un job di sistema sopravvive
+alla configurazione che lo ha creato — ``register_system_job`` non ha una
+controparte che deregistri e ``remove_job`` protegge i ``system_event`` — quindi
+un lavoratore spento resta armato nello store e il suo gestore esce con
+``return None``, cioe' registra ``ok`` senza fare niente. L'heartbeat aggiunge la
+sua variante: acceso, armato, e ``HEARTBEAT.md`` senza task attivi. In tutti
+questi casi lo store dice ``ok`` e la verita' e' «non sta facendo niente», e
+questo e' l'unico posto in cui la differenza puo' diventare visibile.
+
+La config si legge **da disco** e non da un ``Config`` catturato, per la stessa
+ragione per cui la leggono da disco i quattro cancelli in
+``runtime/cron_dispatch.py``: quello del container e' fotografato alla costruzione
+e niente lo aggiorna, quindi un pannello che lo guardasse direbbe «attivo» di un
+worker appena spento dall'utente.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from jenny.cron.heartbeat_tasks import parse_heartbeat_tasks
+from jenny.cron.purposes import system_job_purpose
+from jenny.cron.types import CronJob
+
+# Quanto testo di un promemoria entra nell'elenco. Il resto arriva col dettaglio:
+# una riga di elenco che porta un promemoria intero smette di essere un elenco.
+_MESSAGE_PREVIEW_CHARS = 160
+
+# Dove vive l'interruttore di ciascun lavoratore periodico. **I percorsi non sono
+# simmetrici**, e sono copiati da dove i cancelli veri li leggono
+# (``cron_dispatch._run_dream`` &co.): inventarne uno regolare — per esempio
+# ``gateway.heartbeat`` letto come ``agents.defaults.heartbeat`` — darebbe un
+# ``getattr`` a vuoto, cioe' un worker dichiarato spento per sbaglio.
+_WORKER_ENABLED_PATHS: dict[str, tuple[str, ...]] = {
+    "dream": ("agents", "defaults", "dream", "enabled"),
+    "gardener": ("agents", "defaults", "gardener", "enabled"),
+    "heartbeat": ("gateway", "heartbeat", "enabled"),
+    "update_check": ("updates", "enabled"),
+}
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _dig(root: Any, path: tuple[str, ...]) -> Any:
+    """Segue *path* attributo per attributo. ``None`` se un anello manca.
+
+    ``None`` vuol dire «non lo so», ed e' diverso da ``False``: chi legge non deve
+    poter confondere un flag spento con un percorso sbagliato — v. la nota su
+    ``_WORKER_ENABLED_PATHS``.
+    """
+    node = root
+    for name in path:
+        node = getattr(node, name, None)
+        if node is None:
+            return None
+    return node
+
+
+def _job_kind(job: CronJob) -> str:
+    """``system`` o ``user``, senza far uscire il vocabolario interno.
+
+    Il client non deve conoscere ``system_event``/``agent_turn``: sono i nomi con
+    cui il servizio distingue chi esegue il job, non una categoria che l'utente
+    riconosca.
+    """
+    return "system" if job.payload.kind == "system_event" else "user"
+
+
+def _schedule_payload(job: CronJob) -> dict[str, Any]:
+    """La schedulazione **strutturata**, non una frase.
+
+    Il tool ``cron`` la rende in inglese («every 30m») perche' il suo lettore e'
+    il modello. Questa esce su una UI bilingue, quindi la frase la compone il
+    client: `assets/shared/cron-view.js`, con le sue chiavi i18n.
+    """
+    schedule = job.schedule
+    return {
+        "kind": schedule.kind,
+        "every_ms": schedule.every_ms,
+        "expr": schedule.expr,
+        "at_ms": schedule.at_ms,
+        "tz": schedule.tz,
+    }
+
+
+def _heartbeat_tasks(workspace: Path) -> dict[str, Any]:
+    """Lo stato di ``HEARTBEAT.md``: c'e', si legge, e quanti task attivi ha.
+
+    Il parsing passa da ``parse_heartbeat_tasks``, lo stesso che usa
+    ``CronDispatcher._run_heartbeat`` per decidere se il turno parte. Una seconda
+    scansione qui vorrebbe dire due idee di «cos'e' un task attivo», e quella del
+    pannello si scoprirebbe sbagliata solo il giorno in cui contraddice quella che
+    conta.
+
+    ``file_present`` e ``file_readable`` sono due stati distinti: il file mai
+    creato e' un caso normale su un telefono nuovo, il file che c'e' e non si
+    legge e' un guasto (permessi, o un ``chcon`` perso dopo un ``restorecon``).
+    """
+    path = workspace / "HEARTBEAT.md"
+    if not path.exists():
+        return {"file_present": False, "file_readable": True, "tasks": []}
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("HEARTBEAT.md illeggibile: {}", exc)
+        return {"file_present": True, "file_readable": False, "tasks": []}
+    tasks = parse_heartbeat_tasks(content)
+    return {
+        "file_present": True,
+        "file_readable": True,
+        "tasks": [{"id": t.id, "index": t.index, "label": t.label, "text": t.text} for t in tasks],
+    }
+
+
+def _heartbeat_block(job: CronJob, workspace: Path) -> dict[str, Any]:
+    """Unisce i task del file con le voci di ``task_checks`` dello store.
+
+    Sono due popolazioni diverse e nessuna delle due basta da sola: il file dice
+    **quali controlli esistono**, lo store dice **quali sono rotti** — e le sue
+    voci esistono soltanto finche' lo sono (assente = sano). Incrociandole per
+    ``id`` si ottiene la sola vista completa, e i tre stati che ne escono sono
+    ``ok``, ``broken`` e ``pending`` (affidato a un subagent, verdetto non ancora
+    arrivato).
+
+    ``orphan_checks`` e' il residuo dell'incrocio: una voce nello store senza task
+    nel file. Capita quando l'utente cancella da ``HEARTBEAT.md`` una riga mentre
+    era rotta — niente ripulisce la voce. Non va mostrata fra i controlli rotti
+    (accuserebbe l'utente di un controllo che ha tolto), ma non va nascosta: e' la
+    spiegazione dei contatori a livello di job che altrimenti non avrebbero causa
+    visibile.
+    """
+    file_state = _heartbeat_tasks(workspace)
+    checks = dict(job.state.task_checks)
+    tasks: list[dict[str, Any]] = []
+    for task in file_state["tasks"]:
+        entry = checks.pop(task["id"], None)
+        if entry is None:
+            state = "ok"
+        elif entry.pending_since_ms is not None and not entry.consecutive_could_not_check:
+            state = "pending"
+        elif entry.consecutive_could_not_check:
+            state = "broken"
+        else:
+            state = "ok"
+        tasks.append({
+            **task,
+            "state": state,
+            "consecutive": entry.consecutive_could_not_check if entry else 0,
+            "since_ms": entry.since_ms if entry else None,
+            "escalated": bool(entry.escalated) if entry else False,
+            "escalated_at_ms": entry.escalated_at_ms if entry else None,
+        })
+    orphans = [
+        {
+            "id": task_id,
+            "label": entry.label or "",
+            "consecutive": entry.consecutive_could_not_check,
+            "since_ms": entry.since_ms,
+        }
+        for task_id, entry in checks.items()
+    ]
+    return {
+        "file_present": file_state["file_present"],
+        "file_readable": file_state["file_readable"],
+        "active_task_count": len(file_state["tasks"]),
+        "tasks": tasks,
+        "orphan_checks": orphans,
+    }
+
+
+def _effective(job: CronJob, *, config: Any, heartbeat: dict[str, Any] | None) -> str:
+    """``active``, ``inert`` o ``disabled``: cosa questo job **fa**, non com'e' scritto.
+
+    - ``disabled``: spento nello store, cioe' l'utente (o il tool) l'ha fermato.
+    - ``inert``: armato e in orario, ma qualcosa a valle lo svuota — la config lo
+      ha spento, o per l'heartbeat il file non ha task attivi. Registra ``ok`` a
+      ogni giro senza fare niente, ed e' il caso che il pannello esiste per dire.
+    - ``active``: armato e con qualcosa da fare.
+
+    I promemoria dell'utente non hanno un interruttore in config: per loro
+    ``enabled`` e' tutta la storia.
+    """
+    if not job.enabled:
+        return "disabled"
+    if _job_kind(job) == "user":
+        return "active"
+    path = _WORKER_ENABLED_PATHS.get(job.id)
+    if path is not None:
+        flag = _dig(config, path)
+        # ``None`` = percorso non risolto: si tace invece di dichiarare uno stato
+        # inventato. Un pannello che dice "inerte" perche' non ha trovato un
+        # attributo mente con piu' sicurezza di uno che non dice niente.
+        if flag is False:
+            return "inert"
+    if heartbeat is not None and heartbeat["active_task_count"] == 0:
+        return "inert"
+    return "active"
+
+
+def _job_payload(job: CronJob, *, config: Any, workspace: Path, default_tz: str) -> dict[str, Any]:
+    kind = _job_kind(job)
+    heartbeat = _heartbeat_block(job, workspace) if job.id == "heartbeat" else None
+    message = job.payload.message or ""
+    return {
+        "id": job.id,
+        "name": job.name,
+        "kind": kind,
+        "purpose": system_job_purpose(job.id) if kind == "system" else None,
+        "protected": kind == "system",
+        "enabled": job.enabled,
+        "effective": _effective(job, config=config, heartbeat=heartbeat),
+        "mode": job.payload.mode,
+        "one_shot": job.delete_after_run,
+        # Il testo del promemoria e' contenuto dell'utente: l'anteprima
+        # nell'elenco, l'intero solo nel dettaglio. Per i job di sistema non c'e'
+        # niente da mostrare — il container li registra senza messaggio e il
+        # prompt vero lo costruisce ``bound_runner`` a ogni run.
+        "message_preview": message[:_MESSAGE_PREVIEW_CHARS] if kind == "user" else None,
+        "message": message if kind == "user" else None,
+        # ``schedule.tz`` quando c'e', il default altrimenti: la stessa scelta di
+        # ``CronTool._display_timezone``, cosi' il pannello dice la stessa ora che
+        # Jenny dice in chat.
+        "display_timezone": job.schedule.tz or default_tz,
+        "schedule": _schedule_payload(job),
+        "next_run_at_ms": job.state.next_run_at_ms,
+        "last_run_at_ms": job.state.last_run_at_ms,
+        "last_status": job.state.last_status,
+        "last_error": job.state.last_error,
+        "health": {
+            # A livello di job **non esiste** un ``escalated_at_ms``: ce l'ha la
+            # singola voce di ``task_checks``. Non si aggiunge per simmetria — una
+            # simmetria falsa e' una bugia che il client poi renderizza.
+            "consecutive_could_not_check": job.state.consecutive_could_not_check,
+            "since_ms": job.state.could_not_check_since_ms,
+            "escalated": job.state.could_not_check_escalated,
+        },
+        "runs": [
+            asdict(record)
+            for record in reversed(job.state.run_history)
+        ],
+        "heartbeat": heartbeat,
+    }
+
+
+def webui_cron_payload(
+    cron: Any | None,
+    *,
+    config: Any | None = None,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    """Lo stato della programmazione per la WebUI.
+
+    ``cron=None`` non e' un errore: durante l'onboarding il gateway serve gia' la
+    WebUI e il servizio non e' ancora costruito. Il payload lo dice con
+    ``available: false`` invece di sollevare, cosi' la sezione mostra «non ancora
+    avviato» e non un errore di rete.
+
+    ``config=None`` legge da disco. E' l'idioma di
+    ``cron_dispatch.refresh_system_job`` (``(config or load_config())``): il
+    parametro esiste per i test, il default e' la lettura fresca che la
+    riconciliazione richiede.
+    """
+    from jenny.config.loader import load_config
+    from jenny.runtime.context import get_runtime_context
+
+    stamp = now_ms if now_ms is not None else _now_ms()
+    if cron is None:
+        return {"available": False, "now_ms": stamp, "jobs": []}
+
+    cfg = config if config is not None else load_config()
+    workspace = Path(getattr(cfg, "workspace_path", ".") or ".")
+    default_tz = _dig(cfg, ("agents", "defaults", "timezone")) or "UTC"
+
+    status = cron.status()
+    jobs = [
+        _job_payload(job, config=cfg, workspace=workspace, default_tz=default_tz)
+        # ``include_disabled=True`` e non il default: un job disabilitato e' la
+        # prima cosa che si viene a cercare qui, e senza di lui «l'ho disabilitato
+        # o l'ho cancellato?» resta senza risposta.
+        for job in cron.list_jobs(include_disabled=True)
+    ]
+
+    ctx = get_runtime_context()
+    # Lo stesso stato che le impostazioni mostrano in cima alla schermata. Non e'
+    # un doppione: il banner sta sopra una pagina lunga, l'elenco sta piu' in
+    # basso, e chi lo legge deve sapere **di quell'elenco** che e' stato
+    # ricostruito. Da qui non si puo' rispondere "lo store non si legge": se il
+    # primo caricamento fallisse il gateway non partirebbe affatto
+    # (``CronService._corrupt_store_error``), quindi questa WebUI non esisterebbe.
+    recovery = None
+    if getattr(ctx, "cron_recovered_from", None):
+        recovery = {
+            "restored_from": ctx.cron_recovered_from,
+            "broken_file": str(ctx.cron_quarantine_path) if ctx.cron_quarantine_path else None,
+        }
+
+    return {
+        "available": True,
+        "now_ms": stamp,
+        "service_running": bool(status.get("enabled")),
+        "next_wake_at_ms": status.get("next_wake_at_ms"),
+        "default_timezone": default_tz,
+        "recovery": recovery,
+        "counts": {
+            "total": len(jobs),
+            "enabled": sum(1 for j in jobs if j["enabled"]),
+            "system": sum(1 for j in jobs if j["kind"] == "system"),
+            "user": sum(1 for j in jobs if j["kind"] == "user"),
+            "inert": sum(1 for j in jobs if j["effective"] == "inert"),
+            "broken": sum(1 for j in jobs if j["health"]["consecutive_could_not_check"]),
+        },
+        "jobs": jobs,
+    }

--- a/jenny/webui/cron_routes.py
+++ b/jenny/webui/cron_routes.py
@@ -1,0 +1,77 @@
+"""Route HTTP ``/api/webui/cron`` (stato della programmazione, sola lettura).
+
+Adattatore sottile sopra ``webui/cron_api.webui_cron_payload``: la forma del
+payload e le sue decisioni stanno la', qui c'e' soltanto il trasporto — token,
+thread, codici di stato.
+
+**Sola lettura, e non per pigrizia.** Il servizio ha gia' un imbuto di scrittura
+— il tool ``cron``, piu' ``action.jsonl`` per il merge fra istanze — e aggiungere
+un secondo scrittore da un'altra superficie e' la forma di difetto che
+``config/store.py::mutate`` documenta: chi tiene una copia vecchia cancella in
+silenzio quel che l'altro ha appena scritto. In piu' «esegui adesso»
+(``run_job(force=True)``) accoda un turno d'agente, cioe' spende token e puo' far
+partire una consegna: un pulsante che costa soldi e parla all'utente non entra in
+un pannello di diagnostica per comodita'.
+
+Il servizio arriva come **getter** e non come oggetto, per la stessa ragione di
+``SubagentRoutes``: ``GatewayContainer.cron`` nasce ``None`` e durante
+l'onboarding la WebUI e' gia' servita.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+from websockets.http11 import Request as WsRequest
+from websockets.http11 import Response
+
+from jenny.channels.http_utils import http_error, http_json_response
+from jenny.webui.cron_api import webui_cron_payload
+
+_PATH = "/api/webui/cron"
+
+
+class CronRoutes:
+    """La route della sezione «Programmazione» delle impostazioni."""
+
+    def __init__(
+        self,
+        *,
+        check_api_token: Callable[[WsRequest], bool],
+        get_cron_service: Callable[[], Any | None],
+        log: Any = logger,
+    ) -> None:
+        self._check_api_token = check_api_token
+        self._get_cron_service = get_cron_service
+        self._log = log
+
+    async def dispatch(self, request: WsRequest, path: str) -> Response | None:
+        """``None`` se il path non e' suo: mangiare il dispatch fermerebbe le
+        famiglie di route montate dopo questa."""
+        if path == _PATH:
+            return await self._get(request)
+        return None
+
+    async def _get(self, request: WsRequest) -> Response:
+        if not self._check_api_token(request):
+            return http_error(401, "Unauthorized")
+        try:
+            cron = self._get_cron_service()
+        except Exception:
+            # Il getter e' una lambda sul container: se solleva, il pannello non
+            # deve diventare un 500 — e' lo stesso caso di "non c'e' ancora".
+            self._log.exception("Cron routes: il getter del servizio ha sollevato")
+            cron = None
+        try:
+            # In un thread: ``webui_cron_payload`` legge lo store del cron sotto
+            # il lock del file — lo stesso che prende un ``add_job`` del tool — la
+            # config da disco e ``HEARTBEAT.md``. Sul loop del gateway quel lock
+            # bloccherebbe la chat e la WebSocket, non solo questa risposta.
+            payload = await asyncio.to_thread(webui_cron_payload, cron)
+        except Exception:
+            self._log.exception("Cron status failed")
+            return http_error(500, "cron status failed")
+        return http_json_response(payload)

--- a/jenny/webui/gateway_services.py
+++ b/jenny/webui/gateway_services.py
@@ -59,6 +59,9 @@ def build_gateway_services(
     # dell'AgentLoop). Non un global: l'agente può essere creato dopo il
     # gateway (onboarding), quindi la route lo risolve a ogni chiamata.
     get_subagent_manager: Callable[[], Any | None] | None = None,
+    # Getter late-binding del ``CronService``, come quello sopra: il pannello
+    # della programmazione lo risolve a ogni chiamata.
+    get_cron_service: Callable[[], Any | None] | None = None,
     logger: Any = default_logger,
     onboarding_event: Any | None = None,
     on_settings_changed: Callable[[], None] | None = None,
@@ -90,6 +93,7 @@ def build_gateway_services(
         disabled_skills=disabled_skills,
         snapshot_service=snapshot_service,
         get_subagent_manager=get_subagent_manager,
+        get_cron_service=get_cron_service,
         log=logger,
         onboarding_event=onboarding_event,
         on_settings_changed=on_settings_changed,

--- a/jenny/webui/ws_http.py
+++ b/jenny/webui/ws_http.py
@@ -175,6 +175,7 @@ class GatewayHTTPHandler:
         disabled_skills: set[str] | None = None,
         snapshot_service: Any | None = None,
         get_subagent_manager: Callable[[], Any | None] | None = None,
+        get_cron_service: Callable[[], Any | None] | None = None,
         log: Any = logger,
         onboarding_event: Any | None = None,
         on_settings_changed: Callable[[], None] | None = None,
@@ -261,6 +262,19 @@ class GatewayHTTPHandler:
         self.backup_routes = BackupRoutes(
             check_api_token=self.check_api_secret,
             get_backup_manager=self._get_backup_manager,
+            log=self._log,
+        )
+
+        from jenny.webui.cron_routes import CronRoutes
+
+        # Getter late-binding come quello dei subagent: ``GatewayContainer.cron``
+        # nasce ``None`` e la WebUI e' servita anche durante l'onboarding.
+        self._get_cron_service = get_cron_service
+        self.cron_routes = CronRoutes(
+            check_api_token=self.check_api_secret,
+            get_cron_service=lambda: (
+                self._get_cron_service() if self._get_cron_service is not None else None
+            ),
             log=self._log,
         )
 
@@ -552,6 +566,11 @@ class GatewayHTTPHandler:
         backup_response = await self.backup_routes.dispatch(request, got)
         if backup_response is not None:
             return backup_response
+
+        # Stato della programmazione (delegato a CronRoutes)
+        cron_response = await self.cron_routes.dispatch(request, got)
+        if cron_response is not None:
+            return cron_response
 
         # Stato/controlli dei subagent (delegato a SubagentRoutes)
         subagent_response = await self.subagent_routes.dispatch(request, got)

--- a/tests/cron/test_system_job_purposes.py
+++ b/tests/cron/test_system_job_purposes.py
@@ -1,0 +1,120 @@
+"""La tabella dei propositi copre i job di sistema che il container registra.
+
+Il difetto che questo file esiste per non far tornare: la tabella viveva dentro
+``CronTool`` con sopra un commento — *«Chi ne aggiunge un altro lo aggiunga anche
+qui»* — e il giardiniere non ci era mai stato aggiunto. Chiedendo l'elenco dei job
+si presentava come «System-managed internal job.» pur avendo una pagina di
+documentazione sua. Una regola che chiede disciplina senza un controllo la perde,
+e questo e' il controllo.
+
+**Si legge il sorgente di ``container.py`` invece di costruire un container.**
+Costruirlo vorrebbe dire un provider, un workspace e un event loop per rispondere
+a una domanda che e' statica: *quali id passa questo file a
+``register_system_job``?* L'AST la risponde in modo deterministico, e sbaglia
+soltanto se qualcuno registra un job con un id calcolato a runtime — caso in cui
+il test va aggiornato di proposito, non aggirato.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from jenny.cron.purposes import (
+    SYSTEM_JOB_PURPOSES,
+    UNKNOWN_SYSTEM_JOB_PURPOSE,
+    system_job_purpose,
+)
+
+CONTAINER = Path(__file__).resolve().parents[2] / "jenny" / "runtime" / "container.py"
+
+
+def _registered_system_job_ids() -> set[str]:
+    """Gli ``id`` letterali passati a ``register_system_job(CronJob(id=...))``."""
+    tree = ast.parse(CONTAINER.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "register_system_job"):
+            continue
+        for arg in node.args:
+            if not (isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name)):
+                continue
+            if arg.func.id != "CronJob":
+                continue
+            for kw in arg.keywords:
+                if kw.arg == "id" and isinstance(kw.value, ast.Constant):
+                    found.add(str(kw.value.value))
+    return found
+
+
+def _retired_system_job_ids() -> set[str]:
+    """Il contenuto di ``_RETIRED_SYSTEM_JOBS``, letto dallo stesso sorgente."""
+    tree = ast.parse(CONTAINER.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        targets = []
+        if isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        elif isinstance(node, ast.Assign):
+            targets = node.targets
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == "_RETIRED_SYSTEM_JOBS":
+                value = node.value
+                if isinstance(value, (ast.Tuple, ast.List)):
+                    return {
+                        str(el.value) for el in value.elts if isinstance(el, ast.Constant)
+                    }
+    return set()
+
+
+def test_the_ast_reader_actually_finds_something() -> None:
+    """Guardia sulla guardia: un lettore che non trova nulla passerebbe a vuoto.
+
+    Senza questa riga, un refactor che rinomina ``register_system_job`` o sposta la
+    registrazione altrove renderebbe il test *verde per assenza di dati* — la forma
+    di falso negativo che questo repo ha gia' pagato altrove (un fixture che
+    costruiva il prompt senza la cassetta).
+    """
+    assert len(_registered_system_job_ids()) >= 4
+
+
+def test_every_registered_system_job_can_present_itself() -> None:
+    registered = _registered_system_job_ids()
+    missing = sorted(registered - set(SYSTEM_JOB_PURPOSES))
+    assert not missing, (
+        f"job di sistema registrati senza una riga in SYSTEM_JOB_PURPOSES: {missing}. "
+        "Girano da soli e spendono token o rete: devono sapersi presentare "
+        "(v. jenny/cron/purposes.py)."
+    )
+
+
+def test_the_table_has_no_rows_for_jobs_nobody_registers() -> None:
+    """L'altra direzione: una riga per un job che non esiste piu' e' testo morto.
+
+    I ritirati sono l'eccezione dichiarata — il loro job sparisce dallo store al
+    primo avvio della versione che li ritira, e nel frattempo il fallback dice di
+    loro la cosa giusta — quindi non devono avere una riga.
+    """
+    registered = _registered_system_job_ids()
+    stale = sorted(set(SYSTEM_JOB_PURPOSES) - registered)
+    assert not stale, f"righe in SYSTEM_JOB_PURPOSES per job non registrati: {stale}"
+
+    retired = _retired_system_job_ids()
+    assert retired, "_RETIRED_SYSTEM_JOBS non letto: il controllo sotto passerebbe a vuoto"
+    overlap = sorted(retired & set(SYSTEM_JOB_PURPOSES))
+    assert not overlap, f"job ritirati con una riga di presentazione: {overlap}"
+
+
+def test_an_unknown_job_falls_back_instead_of_raising() -> None:
+    assert system_job_purpose("atlas") == UNKNOWN_SYSTEM_JOB_PURPOSE
+    assert UNKNOWN_SYSTEM_JOB_PURPOSE.strip()
+
+
+def test_no_purpose_is_empty_or_a_placeholder() -> None:
+    for job_id, purpose in SYSTEM_JOB_PURPOSES.items():
+        assert purpose.strip(), job_id
+        assert purpose != UNKNOWN_SYSTEM_JOB_PURPOSE, (
+            f"{job_id} ha come proposito il fallback: e' come non averlo"
+        )

--- a/tests/webui/test_cron_api.py
+++ b/tests/webui/test_cron_api.py
@@ -1,0 +1,449 @@
+"""Il payload della programmazione: cosa dice, e cosa si rifiuta di dire.
+
+Le asserzioni che contano non sono «il dizionario ha le chiavi giuste»: sono i
+casi in cui lo store da solo racconterebbe una bugia con la formattazione giusta
+— un job disabilitato che sparisce, un lavoratore spento che risulta sano, un
+heartbeat che non controlla niente e registra ``ok`` a ogni giro.
+
+I promemoria delle fixture sono **inventati**. Il repo e' pubblico e un test e'
+un documento come un altro: nessun testo vero copiato dal telefono.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from jenny.cron.service import CronService
+from jenny.cron.types import CronJob, CronPayload, CronSchedule, CronTaskCheckState
+from jenny.webui.cron_api import webui_cron_payload
+
+_WATERING = "- Ogni ciclo guarda l'umidita' del vaso e avvisami solo sotto il 15%."
+_PILLS = "- Alle 9 ricordami le gocce."
+
+
+def _heartbeat_file(*tasks: str) -> str:
+    body = "\n".join(tasks)
+    return f"# Heartbeat Tasks\n\n<!-- nota -->\n\n## Active Tasks\n\n{body}\n"
+
+
+def _config(tmp_path, **flags):
+    """Un ``Config`` finto con i quattro interruttori ai percorsi veri."""
+    on = {"dream": True, "gardener": True, "heartbeat": True, "updates": True, **flags}
+    return SimpleNamespace(
+        workspace_path=tmp_path,
+        agents=SimpleNamespace(
+            defaults=SimpleNamespace(
+                timezone="Europe/Rome",
+                dream=SimpleNamespace(enabled=on["dream"]),
+                gardener=SimpleNamespace(enabled=on["gardener"]),
+            )
+        ),
+        gateway=SimpleNamespace(heartbeat=SimpleNamespace(enabled=on["heartbeat"])),
+        updates=SimpleNamespace(enabled=on["updates"]),
+    )
+
+
+@pytest.fixture
+def cron(tmp_path):
+    return CronService(tmp_path / "cron" / "jobs.json")
+
+
+def _system(job_id: str, *, every_ms: int = 1_800_000) -> CronJob:
+    return CronJob(
+        id=job_id,
+        name=job_id,
+        schedule=CronSchedule(kind="every", every_ms=every_ms),
+        payload=CronPayload(kind="system_event"),
+    )
+
+
+# ── il caso in cui il servizio non c'e' ancora ──────────────────────────────
+
+def test_no_service_yet_is_a_state_not_an_error(tmp_path):
+    """Durante l'onboarding la WebUI e' servita e il cron non esiste."""
+    payload = webui_cron_payload(None, config=_config(tmp_path))
+
+    assert payload["available"] is False
+    assert payload["jobs"] == []
+    assert payload["now_ms"] > 0
+
+
+# ── §5.1: i disabilitati non devono sparire ─────────────────────────────────
+
+def test_a_disabled_job_is_listed_not_hidden(cron, tmp_path):
+    """``list_jobs()`` filtra per default, e il filtro qui e' una bugia.
+
+    Senza questo, «l'ho disabilitato o l'ho cancellato?» resta senza risposta —
+    che e' una delle domande per cui il pannello esiste.
+    """
+    job = cron.add_job("gocce", CronSchedule(kind="every", every_ms=60_000), _PILLS)
+    cron.enable_job(job.id, False)
+
+    payload = webui_cron_payload(cron, config=_config(tmp_path))
+
+    ids = [j["id"] for j in payload["jobs"]]
+    assert job.id in ids
+    row = next(j for j in payload["jobs"] if j["id"] == job.id)
+    assert row["enabled"] is False
+    assert row["effective"] == "disabled"
+    assert payload["counts"]["total"] == 1
+    assert payload["counts"]["enabled"] == 0
+
+
+# ── §5.8: armato e inerte ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("job_id", "flag"),
+    [("dream", "dream"), ("gardener", "gardener"), ("update_check", "updates")],
+)
+def test_a_worker_switched_off_in_config_is_inert_not_healthy(cron, tmp_path, job_id, flag):
+    """Il job resta armato nello store e il gestore esce con ``return None``.
+
+    Cioe' registra ``ok`` senza fare niente: qui e' l'unico posto in cui la
+    differenza puo' diventare visibile.
+    """
+    cron.register_system_job(_system(job_id))
+    job = cron.get_job(job_id)
+    job.state.last_status = "ok"
+    cron.persist_job_state()
+
+    payload = webui_cron_payload(cron, config=_config(tmp_path, **{flag: False}))
+    row = next(j for j in payload["jobs"] if j["id"] == job_id)
+
+    assert row["enabled"] is True, "nello store e' ancora armato: e' il punto"
+    assert row["last_status"] == "ok", "e continua a registrare ok"
+    assert row["effective"] == "inert"
+    assert payload["counts"]["inert"] == 1
+
+
+def test_a_worker_switched_on_is_active(cron, tmp_path):
+    cron.register_system_job(_system("gardener"))
+
+    payload = webui_cron_payload(cron, config=_config(tmp_path))
+
+    assert next(j for j in payload["jobs"] if j["id"] == "gardener")["effective"] == "active"
+    assert payload["counts"]["inert"] == 0
+
+
+def test_an_unresolvable_flag_path_does_not_invent_inert(cron, tmp_path):
+    """Un attributo che manca vuol dire «non lo so», non «spento».
+
+    Un pannello che dichiara "inerte" perche' non ha trovato un attributo mente
+    con piu' sicurezza di uno che non dice niente.
+    """
+    cron.register_system_job(_system("dream"))
+    broken = SimpleNamespace(workspace_path=tmp_path)  # nessun ``agents``
+
+    row = webui_cron_payload(cron, config=broken)["jobs"][0]
+
+    assert row["effective"] == "active"
+
+
+# ── §4.2: l'heartbeat e i suoi task ─────────────────────────────────────────
+
+def test_a_heartbeat_with_no_task_file_is_checking_nothing(cron, tmp_path):
+    """Il caso peggiore: gira ogni mezz'ora, registra ``ok``, non controlla niente."""
+    cron.register_system_job(_system("heartbeat"))
+    job = cron.get_job("heartbeat")
+    job.state.last_status = "ok"
+    cron.persist_job_state()
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["last_status"] == "ok"
+    assert row["heartbeat"]["file_present"] is False
+    assert row["heartbeat"]["active_task_count"] == 0
+    assert row["effective"] == "inert"
+
+
+def test_a_task_file_with_only_headings_is_also_checking_nothing(cron, tmp_path):
+    (tmp_path / "HEARTBEAT.md").write_text(_heartbeat_file(""), encoding="utf-8")
+    cron.register_system_job(_system("heartbeat"))
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["heartbeat"]["file_present"] is True
+    assert row["heartbeat"]["file_readable"] is True
+    assert row["heartbeat"]["active_task_count"] == 0
+    assert row["effective"] == "inert"
+
+
+def test_an_unreadable_task_file_is_a_third_state(cron, tmp_path, monkeypatch):
+    """Il file che c'e' e non si legge e' un guasto, non un file mai creato."""
+    path = tmp_path / "HEARTBEAT.md"
+    path.write_text(_heartbeat_file(_WATERING), encoding="utf-8")
+    original = type(path).read_text
+
+    def _boom(self, *a, **kw):
+        if self.name == "HEARTBEAT.md":
+            raise OSError("permessi")
+        return original(self, *a, **kw)
+
+    monkeypatch.setattr(type(path), "read_text", _boom)
+    cron.register_system_job(_system("heartbeat"))
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["heartbeat"]["file_present"] is True
+    assert row["heartbeat"]["file_readable"] is False
+
+
+def test_healthy_tasks_are_listed_with_no_check_entries(cron, tmp_path):
+    (tmp_path / "HEARTBEAT.md").write_text(
+        _heartbeat_file(_WATERING, _PILLS), encoding="utf-8"
+    )
+    cron.register_system_job(_system("heartbeat"))
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["heartbeat"]["active_task_count"] == 2
+    assert [t["state"] for t in row["heartbeat"]["tasks"]] == ["ok", "ok"]
+    assert row["heartbeat"]["orphan_checks"] == []
+    assert row["effective"] == "active"
+
+
+def test_the_join_marks_broken_and_pending_and_leaves_the_rest_ok(cron, tmp_path):
+    """Le tre specie in una volta: il file dice quali esistono, lo store quali no."""
+    from jenny.cron.heartbeat_tasks import parse_heartbeat_tasks
+
+    content = _heartbeat_file(_WATERING, _PILLS)
+    (tmp_path / "HEARTBEAT.md").write_text(content, encoding="utf-8")
+    tasks = parse_heartbeat_tasks(content)
+
+    cron.register_system_job(_system("heartbeat"))
+    job = cron.get_job("heartbeat")
+    job.state.task_checks[tasks[0].id] = CronTaskCheckState(
+        consecutive_could_not_check=3, since_ms=1_000, label=tasks[0].label, escalated=True,
+        escalated_at_ms=2_000,
+    )
+    job.state.task_checks[tasks[1].id] = CronTaskCheckState(
+        pending_since_ms=3_000, label=tasks[1].label
+    )
+    cron.persist_job_state()
+
+    hb = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]["heartbeat"]
+    by_id = {t["id"]: t for t in hb["tasks"]}
+
+    assert by_id[tasks[0].id]["state"] == "broken"
+    assert by_id[tasks[0].id]["consecutive"] == 3
+    assert by_id[tasks[0].id]["escalated"] is True
+    assert by_id[tasks[0].id]["escalated_at_ms"] == 2_000
+    assert by_id[tasks[1].id]["state"] == "pending"
+    assert by_id[tasks[1].id]["consecutive"] == 0
+    assert hb["orphan_checks"] == []
+
+
+def test_a_check_without_a_task_becomes_an_orphan_not_a_broken_check(cron, tmp_path):
+    """L'utente ha cancellato la riga mentre era rotta: niente ripulisce la voce.
+
+    Mostrarla fra i controlli rotti lo accuserebbe di un controllo che ha tolto;
+    nasconderla lascerebbe i contatori del job senza causa visibile.
+    """
+    (tmp_path / "HEARTBEAT.md").write_text(_heartbeat_file(_WATERING), encoding="utf-8")
+    cron.register_system_job(_system("heartbeat"))
+    job = cron.get_job("heartbeat")
+    job.state.task_checks["un-id-che-non-e-piu-nel-file"] = CronTaskCheckState(
+        consecutive_could_not_check=5, since_ms=1_000, label="un controllo tolto"
+    )
+    cron.persist_job_state()
+
+    hb = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]["heartbeat"]
+
+    assert [t["state"] for t in hb["tasks"]] == ["ok"]
+    assert len(hb["orphan_checks"]) == 1
+    assert hb["orphan_checks"][0]["consecutive"] == 5
+
+
+def test_only_the_heartbeat_carries_the_heartbeat_block(cron, tmp_path):
+    cron.register_system_job(_system("dream"))
+
+    assert webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]["heartbeat"] is None
+
+
+# ── identita', vocabolario, fusi ────────────────────────────────────────────
+
+def test_a_system_job_presents_itself_and_cannot_be_removed(cron, tmp_path):
+    cron.register_system_job(_system("gardener"))
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["kind"] == "system"
+    assert row["protected"] is True
+    assert row["purpose"] and "Gardener" in row["purpose"]
+    assert row["message"] is None and row["message_preview"] is None
+
+
+def test_a_user_job_carries_a_preview_in_the_list_and_the_whole_text_in_the_detail(
+    cron, tmp_path
+):
+    long_text = "Ricordami " + ("x" * 400)
+    cron.add_job("lungo", CronSchedule(kind="every", every_ms=60_000), long_text)
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["kind"] == "user"
+    assert row["protected"] is False
+    assert row["purpose"] is None
+    assert len(row["message_preview"]) == 160
+    assert row["message"] == long_text
+
+
+def test_the_schedule_travels_structured_not_as_an_english_sentence(cron, tmp_path):
+    """La frase la compone il client: questa UI e' bilingue, il tool no."""
+    cron.add_job("orario", CronSchedule(kind="cron", expr="0 9 * * *", tz="Europe/Rome"), _PILLS)
+
+    row = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]
+
+    assert row["schedule"] == {
+        "kind": "cron", "every_ms": None, "expr": "0 9 * * *",
+        "at_ms": None, "tz": "Europe/Rome",
+    }
+    # Nessun campo pre-formattato: se un giorno ne comparisse uno, il client
+    # smetterebbe di essere l'unico a decidere in che lingua si legge.
+    assert set(row["schedule"]) == {"kind", "every_ms", "expr", "at_ms", "tz"}
+
+
+def test_the_display_timezone_is_the_job_s_own_then_the_default(cron, tmp_path):
+    """La stessa scelta di ``CronTool._display_timezone``: il pannello e la chat
+    devono dire la stessa ora."""
+    cron.add_job("con-tz", CronSchedule(kind="cron", expr="0 9 * * *", tz="Asia/Tokyo"), _PILLS)
+    cron.add_job("senza-tz", CronSchedule(kind="every", every_ms=60_000), _PILLS)
+
+    rows = {j["name"]: j for j in webui_cron_payload(cron, config=_config(tmp_path))["jobs"]}
+
+    assert rows["con-tz"]["display_timezone"] == "Asia/Tokyo"
+    assert rows["senza-tz"]["display_timezone"] == "Europe/Rome"
+
+
+def test_the_monitor_mode_travels(cron, tmp_path):
+    """Un monitor che tace ha funzionato: senza questo bit il client non lo sa."""
+    cron.add_job(
+        "monitor", CronSchedule(kind="every", every_ms=60_000), _WATERING, mode="monitor"
+    )
+
+    assert webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]["mode"] == "monitor"
+
+
+def test_the_job_level_health_has_no_invented_escalated_at(cron, tmp_path):
+    """A livello di job quel campo non esiste: ce l'ha la voce di ``task_checks``.
+
+    Una simmetria falsa e' una bugia che il client poi renderizza.
+    """
+    cron.register_system_job(_system("heartbeat"))
+    job = cron.get_job("heartbeat")
+    job.state.consecutive_could_not_check = 2
+    job.state.could_not_check_since_ms = 1_000
+    job.state.could_not_check_escalated = True
+    cron.persist_job_state()
+
+    health = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]["health"]
+
+    assert health == {
+        "consecutive_could_not_check": 2, "since_ms": 1_000, "escalated": True,
+    }
+
+
+def test_the_run_history_comes_back_newest_first(cron, tmp_path):
+    from jenny.cron.types import CronRunRecord
+
+    cron.register_system_job(_system("dream"))
+    job = cron.get_job("dream")
+    job.state.run_history = [
+        CronRunRecord(run_at_ms=1_000, status="ok", duration_ms=10),
+        CronRunRecord(run_at_ms=2_000, status="silenced", duration_ms=20),
+    ]
+    cron.persist_job_state()
+
+    runs = webui_cron_payload(cron, config=_config(tmp_path))["jobs"][0]["runs"]
+
+    assert [r["run_at_ms"] for r in runs] == [2_000, 1_000]
+    assert runs[0]["status"] == "silenced"
+
+
+# ── privacy: l'audit interno non passa da qui ───────────────────────────────
+
+def test_the_payload_never_carries_a_rendered_prompt_or_a_response(cron, tmp_path):
+    """I record in ``cron/runs/`` sono un audit interno e restano fuori.
+
+    Asserzione sul JSON e non sui campi noti: cosi' regge anche a un campo
+    aggiunto domani.
+    """
+    cron.register_system_job(_system("dream"))
+    cron.add_job("promemoria", CronSchedule(kind="every", every_ms=60_000), _PILLS)
+    cron.write_run_record(
+        "dream:1:abc",
+        {"rendered_prompt": "SEGRETO-PROMPT", "response": "SEGRETO-RISPOSTA"},
+    )
+
+    blob = json.dumps(webui_cron_payload(cron, config=_config(tmp_path)), ensure_ascii=False)
+
+    assert "rendered_prompt" not in blob
+    assert "SEGRETO-PROMPT" not in blob
+    assert "SEGRETO-RISPOSTA" not in blob
+
+
+# ── coerenza col banner di recupero ─────────────────────────────────────────
+
+def test_the_panel_says_the_list_was_rebuilt_at_startup(cron, tmp_path, monkeypatch):
+    """Lo stesso stato che le impostazioni mostrano in cima alla schermata.
+
+    Non e' un doppione: il banner sta sopra una pagina lunga, l'elenco piu' in
+    basso, e chi lo legge deve sapere **di quell'elenco** che e' stato
+    ricostruito.
+    """
+    ctx = SimpleNamespace(
+        cron_recovered_from="empty", cron_quarantine_path=tmp_path / "jobs.json.corrupt-1"
+    )
+    import jenny.runtime.context as context_mod
+
+    monkeypatch.setattr(context_mod, "get_runtime_context", lambda: ctx)
+
+    payload = webui_cron_payload(cron, config=_config(tmp_path))
+
+    assert payload["recovery"]["restored_from"] == "empty"
+    assert payload["recovery"]["broken_file"].endswith("jobs.json.corrupt-1")
+
+
+def test_a_healthy_start_reports_no_recovery(cron, tmp_path):
+    assert webui_cron_payload(cron, config=_config(tmp_path))["recovery"] is None
+
+
+# ── la config si legge da disco ─────────────────────────────────────────────
+
+def test_without_a_config_it_reads_from_disk(cron, tmp_path, monkeypatch):
+    """Il vincolo che la correzione di Dream lascia in eredita'.
+
+    I quattro cancelli chiamano ``load_config()`` e non ``self._config``, perche'
+    quello del container e' fotografato alla costruzione. Un pannello che
+    guardasse la fotografia direbbe «attivo» di un worker appena spento.
+    """
+    import jenny.config.loader as loader
+
+    calls: list[int] = []
+
+    def _fake_load_config():
+        calls.append(1)
+        return _config(tmp_path, dream=False)
+
+    monkeypatch.setattr(loader, "load_config", _fake_load_config)
+    cron.register_system_job(_system("dream"))
+
+    row = webui_cron_payload(cron)["jobs"][0]
+
+    assert calls, "la config non e' stata riletta da disco"
+    assert row["effective"] == "inert"
+
+
+# ── stato del servizio ──────────────────────────────────────────────────────
+
+def test_a_stopped_scheduler_is_reported(cron, tmp_path):
+    """Un elenco perfetto col servizio fermo e' una bugia con la formattazione
+    giusta: le scadenze nello store sono nel passato e nessuno le rimette."""
+    cron.register_system_job(_system("dream"))
+
+    payload = webui_cron_payload(cron, config=_config(tmp_path))
+
+    assert payload["service_running"] is False

--- a/tests/webui/test_cron_routes.py
+++ b/tests/webui/test_cron_routes.py
@@ -1,0 +1,183 @@
+"""Le route ``/api/webui/cron``: token, thread, e i codici di stato.
+
+Stesso pattern di ``test_skills_routes.py`` e ``test_backup_routes.py``: si
+costruisce un ``GatewayHTTPHandler`` vero con dipendenze finte e si dispatcha una
+``websockets.http11.Request``. Il payload lo prova ``test_cron_api.py``; qui si
+prova soltanto il trasporto.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.parse
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from websockets.http11 import Headers
+from websockets.http11 import Request as WsRequest
+
+from jenny.webui.ws_http import GatewayHTTPHandler
+
+_AUTH_SECRET = "test-secret"
+_PATH = "/api/webui/cron"
+
+
+def _make_handler(workspace: Path, *, get_cron_service=None) -> GatewayHTTPHandler:
+    config = SimpleNamespace(
+        workspace=SimpleNamespace(enabled=True),
+        wiki=SimpleNamespace(enabled=True, wikis_dir="wikis"),
+        token_issue_secret=_AUTH_SECRET,
+        verbose=False,
+    )
+    return GatewayHTTPHandler(
+        config=config,
+        session_manager=None,
+        runtime_model_name=lambda: "test-model",
+        bus=MagicMock(),
+        media=MagicMock(),
+        workspaces=MagicMock(),
+        skills_workspace_path=workspace,
+        get_cron_service=get_cron_service,
+    )
+
+
+def _request(path: str = _PATH, *, token: str | None = _AUTH_SECRET) -> WsRequest:
+    if token is None:
+        return WsRequest(path=path, headers=Headers())
+    sep = "&" if "?" in path else "?"
+    return WsRequest(path=f"{path}{sep}token={urllib.parse.quote(token)}", headers=Headers())
+
+
+def _dispatch(handler: GatewayHTTPHandler, path: str = _PATH, *, token=_AUTH_SECRET):
+    return asyncio.run(handler.cron_routes.dispatch(_request(path, token=token), path))
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "data" / "workspace"
+    ws.mkdir(parents=True)
+    return ws
+
+
+def test_a_request_without_a_token_is_refused(workspace):
+    handler = _make_handler(workspace, get_cron_service=lambda: MagicMock())
+
+    response = _dispatch(handler, token=None)
+
+    assert response.status_code == 401
+
+
+def test_a_request_with_the_wrong_token_is_refused(workspace):
+    handler = _make_handler(workspace, get_cron_service=lambda: MagicMock())
+
+    response = _dispatch(handler, token="non-e-il-segreto")
+
+    assert response.status_code == 401
+
+
+def test_another_path_is_left_to_the_families_mounted_after_this_one(workspace):
+    """``dispatch`` deve ritornare ``None``, non una risposta.
+
+    Mangiare il dispatch fermerebbe le route montate dopo — un difetto che si
+    manifesta in *altre* funzionalita', non in questa.
+    """
+    handler = _make_handler(workspace, get_cron_service=lambda: MagicMock())
+
+    assert _dispatch(handler, "/api/webui/skills") is None
+    assert _dispatch(handler, "/api/webui/cron/extra") is None
+
+
+def test_without_a_service_it_answers_not_available_instead_of_failing(workspace):
+    """Durante l'onboarding la WebUI e' servita e il cron non c'e' ancora."""
+    handler = _make_handler(workspace, get_cron_service=None)
+
+    response = _dispatch(handler)
+
+    assert response.status_code == 200
+    assert json.loads(response.body)["available"] is False
+
+
+def test_a_getter_that_raises_is_treated_as_no_service(workspace):
+    def _boom():
+        raise RuntimeError("container a meta' costruzione")
+
+    handler = _make_handler(workspace, get_cron_service=_boom)
+
+    response = _dispatch(handler)
+
+    assert response.status_code == 200
+    assert json.loads(response.body)["available"] is False
+
+
+def test_a_real_service_comes_back_as_json(workspace, monkeypatch):
+    from jenny.cron.service import CronService
+    from jenny.cron.types import CronJob, CronPayload, CronSchedule
+
+    cron = CronService(workspace / "cron" / "jobs.json")
+    cron.register_system_job(CronJob(
+        id="dream", name="dream",
+        schedule=CronSchedule(kind="every", every_ms=3_600_000),
+        payload=CronPayload(kind="system_event"),
+    ))
+
+    import jenny.config.loader as loader
+
+    monkeypatch.setattr(loader, "load_config", lambda: SimpleNamespace(
+        workspace_path=workspace,
+        agents=SimpleNamespace(defaults=SimpleNamespace(
+            timezone="Europe/Rome", dream=SimpleNamespace(enabled=True),
+            gardener=SimpleNamespace(enabled=True),
+        )),
+        gateway=SimpleNamespace(heartbeat=SimpleNamespace(enabled=True)),
+        updates=SimpleNamespace(enabled=True),
+    ))
+
+    handler = _make_handler(workspace, get_cron_service=lambda: cron)
+    response = _dispatch(handler)
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload["available"] is True
+    assert [j["id"] for j in payload["jobs"]] == ["dream"]
+
+
+def test_a_failing_payload_becomes_a_500_and_not_a_traceback(workspace, monkeypatch):
+    import jenny.webui.cron_routes as routes
+
+    def _boom(_cron):
+        raise OSError("disco")
+
+    monkeypatch.setattr(routes, "webui_cron_payload", _boom)
+    handler = _make_handler(workspace, get_cron_service=lambda: MagicMock())
+
+    response = _dispatch(handler)
+
+    assert response.status_code == 500
+
+
+def test_the_payload_is_built_off_the_event_loop(workspace, monkeypatch):
+    """Legge lo store sotto il lock del file: sul loop bloccherebbe la chat.
+
+    La spia e' su ``asyncio.to_thread``, non sul thread reale: quel che va
+    fissato e' la scelta, non l'implementazione di asyncio.
+    """
+    import jenny.webui.cron_routes as routes
+
+    seen: list[object] = []
+    real_to_thread = asyncio.to_thread
+
+    async def _spy(fn, *args, **kwargs):
+        seen.append(fn)
+        return await real_to_thread(fn, *args, **kwargs)
+
+    monkeypatch.setattr(routes.asyncio, "to_thread", _spy)
+    monkeypatch.setattr(routes, "webui_cron_payload", lambda _cron: {"available": True})
+    handler = _make_handler(workspace, get_cron_service=lambda: MagicMock())
+
+    response = _dispatch(handler)
+
+    assert response.status_code == 200
+    assert seen, "il payload e' stato costruito sul loop del gateway"

--- a/tests/webui/test_cron_view_client.py
+++ b/tests/webui/test_cron_view_client.py
@@ -1,0 +1,421 @@
+"""Il modello di vista della programmazione, eseguito davvero sotto node.
+
+``shared/cron-view.js`` e' puro di proposito — niente DOM, niente ``window``,
+niente i18n — perche' i casi che deve azzeccare sono esattamente quelli che sul
+telefono non si riescono a fabbricare: uno scheduler fermo, una scadenza nel
+passato, un worker spento dalla config. Stesso idioma di
+``test_launcher_rank_client.py``: il modulo si importa in node e le asserzioni
+girano contro il codice vero.
+
+Il caso che da' il nome al file, se dovesse averne uno, e' ``silenced``: un
+monitor che tace **ha funzionato**, e un pannello che lo colora di rosso insegna
+all'utente a ignorare i colori. E' la classe di difetto piu' silenziosa qui —
+niente si rompe, l'informazione si limita a diventare inutile.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+VIEW_JS = (
+    Path(__file__).resolve().parents[2]
+    / "jenny" / "templates" / "ui" / "assets" / "shared" / "cron-view.js"
+)
+
+_NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(_NODE is None, reason="node non disponibile")
+
+# ``tr`` finta: ritorna la chiave piu' i parametri, cosi' un'asserzione dice
+# quale stringa e' stata scelta senza dipendere da una traduzione vera. Il
+# modulo prende ``tr`` dal chiamante proprio per questo — importare i18n lo
+# renderebbe non provabile qui.
+_HARNESS = """
+import assert from 'node:assert/strict';
+const tr = (key, params) => (params ? key + ':' + JSON.stringify(params) : key);
+const NOW = 1_700_000_000_000;
+"""
+
+
+def _run_js(script: str) -> str:
+    source = VIEW_JS.read_text(encoding="utf-8") + _HARNESS + script
+    proc = subprocess.run(
+        [str(_NODE), "--input-type=module", "-e", source],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={"TZ": "Europe/Rome", "PATH": "/usr/bin:/bin:/usr/local/bin"},
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return proc.stdout
+
+
+# ── il vocabolario dei cinque esiti ─────────────────────────────────────────
+
+def test_a_silent_monitor_is_not_a_failure() -> None:
+    out = _run_js("""
+      console.log(JSON.stringify({
+        ok: statusTone('ok'),
+        silenced: statusTone('silenced'),
+        skipped: statusTone('skipped'),
+        could_not_check: statusTone('could_not_check'),
+        error: statusTone('error'),
+      }));
+    """)
+    tones = json.loads(out)
+
+    assert tones["silenced"] == "neutral", "un monitor che tace ha guardato e non aveva nulla"
+    assert tones["skipped"] == "neutral"
+    assert tones["could_not_check"] == "warn", "il terzo stato non e' un errore"
+    assert tones["error"] == "bad"
+    assert tones["could_not_check"] != tones["error"]
+
+
+def test_an_outcome_this_version_does_not_know_is_neutral_not_broken() -> None:
+    """Uno store scritto da una versione piu' nuova non deve sembrare un guasto."""
+    out = _run_js("console.log(statusTone('qualcosa_di_domani'));")
+
+    assert out.strip() == "neutral"
+
+
+# ── §5.3: la scadenza persistita puo' essere nel passato ────────────────────
+
+def test_a_next_run_in_the_past_is_reported_as_overdue() -> None:
+    out = _run_js("""
+      const past = formatWhen(NOW - 3 * 3_600_000, { nowMs: NOW, tr, locale: 'it' });
+      const future = formatWhen(NOW + 30 * 60_000, { nowMs: NOW, tr, locale: 'it' });
+      console.log(JSON.stringify({ past, future }));
+    """)
+    data = json.loads(out)
+
+    assert data["past"]["overdue"] is True
+    assert data["past"]["relative"].startswith("cron.when.ago")
+    assert data["future"]["overdue"] is False
+    assert data["future"]["relative"].startswith("cron.when.in")
+
+
+def test_the_now_window_does_not_call_a_due_job_late() -> None:
+    """Entro tre quarti di minuto si dice «adesso»: un job che sta scattando non
+    e' in ritardo, e non e' nemmeno «fra 0 minuti»."""
+    out = _run_js("""
+      console.log(JSON.stringify([
+        formatWhen(NOW, { nowMs: NOW, tr }),
+        formatWhen(NOW - 30_000, { nowMs: NOW, tr }),
+        formatWhen(NOW - 60_000, { nowMs: NOW, tr }),
+      ]));
+    """)
+    now, borderline, late = json.loads(out)
+
+    assert now["relative"] == "cron.when.now"
+    assert borderline["relative"] == "cron.when.now"
+    assert borderline["overdue"] is False
+    assert late["overdue"] is True
+
+
+def test_a_missing_timestamp_is_null_not_a_fake_date() -> None:
+    out = _run_js("""
+      console.log(JSON.stringify([
+        formatWhen(null, { nowMs: NOW, tr }),
+        formatWhen(undefined, { nowMs: NOW, tr }),
+      ]));
+    """)
+
+    assert json.loads(out) == [None, None]
+
+
+# ── §5.4: il fuso si nomina solo quando dice qualcosa ───────────────────────
+
+def test_the_time_zone_is_named_only_when_it_differs_from_the_device() -> None:
+    """Il test gira con ``TZ=Europe/Rome``: Roma non va nominata, Tokyo sì."""
+    out = _run_js("""
+      console.log(JSON.stringify({
+        same: timeZoneNote('Europe/Rome'),
+        other: timeZoneNote('Asia/Tokyo'),
+        none: timeZoneNote(null),
+      }));
+    """)
+    notes = json.loads(out)
+
+    assert notes["same"] is None
+    assert notes["other"] == "Asia/Tokyo"
+    assert notes["none"] is None
+
+
+def test_a_time_zone_intl_rejects_does_not_take_the_row_down() -> None:
+    """Uno store scritto a mano puo' portare un fuso che non esiste."""
+    out = _run_js("""
+      const when = formatWhen(NOW, { nowMs: NOW, tr, locale: 'it', timeZone: 'Marte/Olympus' });
+      console.log(JSON.stringify(when.absolute.length > 0));
+    """)
+
+    assert json.loads(out) is True
+
+
+# ── la schedulazione, composta qui e non dal server ─────────────────────────
+
+def test_each_schedule_kind_gets_its_own_sentence() -> None:
+    out = _run_js("""
+      const say = (s) => describeSchedule(s, { tr, locale: 'it', timeZone: 'Europe/Rome' });
+      console.log(JSON.stringify({
+        every: say({ kind: 'every', every_ms: 1_800_000 }),
+        hours: say({ kind: 'every', every_ms: 7_200_000 }),
+        expr: say({ kind: 'cron', expr: '0 9 * * *' }),
+        at: say({ kind: 'at', at_ms: NOW }),
+        junk: say({ kind: 'every' }),
+      }));
+    """)
+    said = json.loads(out)
+
+    assert said["every"].startswith("cron.schedule.every")
+    # La durata e' annidata dentro i parametri, quindi le virgolette sono
+    # sfuggite una volta: si asserisce sulla forma vera, non su quella comoda.
+    # ``n`` arriva formattato per la lingua, quindi e' una stringa: v.
+    # ``test_the_decimal_separator_follows_the_locale``.
+    assert "cron.unit.minutes" in said["every"] and '30' in said["every"]
+    assert "cron.unit.hours" in said["hours"] and '2' in said["hours"]
+    assert said["expr"] == 'cron.schedule.expr:{"expr":"0 9 * * *"}'
+    assert said["at"].startswith("cron.schedule.at")
+    assert said["junk"] == "cron.schedule.unknown", "una schedulazione incompleta non inventa"
+
+
+def test_a_non_round_interval_keeps_one_decimal_instead_of_vanishing() -> None:
+    """«ogni 2,5 ore» arrotondato a 2 sarebbe una schedulazione diversa."""
+    out = _run_js("""
+      console.log(humanizeDuration(9_000_000, { tr, locale: 'it' }));
+    """)
+
+    assert "2,5" in out
+
+
+def test_the_decimal_separator_follows_the_locale() -> None:
+    """Difetto visto sul telefono il 10/09/2026: «1.9 ore fa» in italiano.
+
+    Il numero veniva interpolato grezzo. Cambia una virgola, e cambia su ogni
+    riga che porta un'ora e mezza.
+    """
+    out = _run_js("""
+      console.log(JSON.stringify({
+        it: humanizeDuration(6_840_000, { tr, locale: 'it' }),
+        en: humanizeDuration(6_840_000, { tr, locale: 'en' }),
+        noLocale: humanizeDuration(6_840_000, { tr }),
+      }));
+    """)
+    said = json.loads(out)
+
+    assert "1,9" in said["it"] and "1.9" not in said["it"]
+    assert "1.9" in said["en"]
+    # Senza locale si delega al default dell'ambiente invece di sollevare.
+    assert said["noLocale"]
+
+
+def test_one_of_a_unit_asks_for_the_singular_key() -> None:
+    """``i18n.t`` non pluralizza, e «1 minuti» si legge a ogni riga.
+
+    La scelta della chiave sta nel modulo puro proprio per poterla provare qui.
+    """
+    out = _run_js("""
+      console.log(JSON.stringify({
+        one_minute: humanizeDuration(60_000, { tr }),
+        two_minutes: humanizeDuration(120_000, { tr }),
+        one_hour: humanizeDuration(3_600_000, { tr }),
+        one_day: humanizeDuration(86_400_000, { tr }),
+        one_second: humanizeDuration(900, { tr }),
+      }));
+    """)
+    said = json.loads(out)
+
+    assert said["one_minute"].startswith("cron.unit.minute:")
+    assert said["two_minutes"].startswith("cron.unit.minutes:")
+    assert said["one_hour"].startswith("cron.unit.hour:")
+    assert said["one_day"].startswith("cron.unit.day:")
+    assert said["one_second"].startswith("cron.unit.second:")
+
+
+# ── ordinamento: prima quel che chiede attenzione ───────────────────────────
+
+def test_broken_first_then_inert_then_by_next_run_and_disabled_last() -> None:
+    out = _run_js("""
+      const job = (over) => ({
+        name: over.name, enabled: over.enabled ?? true,
+        effective: over.effective ?? 'active',
+        next_run_at_ms: over.next ?? null,
+        health: { consecutive_could_not_check: over.cnc ?? 0 },
+      });
+      const jobs = [
+        job({ name: 'spento', enabled: false, effective: 'disabled', next: NOW + 1 }),
+        job({ name: 'tardi', next: NOW + 9_000_000 }),
+        job({ name: 'presto', next: NOW + 1_000 }),
+        job({ name: 'inerte', effective: 'inert', next: NOW + 2 }),
+        job({ name: 'rotto', cnc: 3, next: NOW + 9_999_999 }),
+        job({ name: 'senza-scadenza' }),
+      ];
+      console.log(JSON.stringify(jobs.sort(compareJobs).map((j) => j.name)));
+    """)
+
+    assert json.loads(out) == [
+        "rotto", "inerte", "presto", "tardi", "senza-scadenza", "spento",
+    ]
+
+
+def test_health_puts_a_broken_worker_above_an_inert_one() -> None:
+    out = _run_js("""
+      console.log(JSON.stringify({
+        broken: jobHealth({ effective: 'inert', health: { consecutive_could_not_check: 2 } }),
+        inert: jobHealth({ effective: 'inert', health: { consecutive_could_not_check: 0 } }),
+        off: jobHealth({ effective: 'disabled', health: {} }),
+        ok: jobHealth({ effective: 'active', health: {} }),
+      }));
+    """)
+
+    assert json.loads(out) == {
+        "broken": "broken", "inert": "inert", "off": "off", "ok": "ok",
+    }
+
+
+# ── il banner: uno solo, il piu' utile ──────────────────────────────────────
+
+def test_the_banner_prefers_the_explanation_that_covers_the_whole_list() -> None:
+    """Uno scheduler fermo spiega da solo ogni «in ritardo» della lista: senza di
+    lui la stessa spiegazione andrebbe ripetuta su ogni riga."""
+    out = _run_js("""
+      const inert = [{ name: 'heartbeat', effective: 'inert' }];
+      console.log(JSON.stringify({
+        unavailable: pickBanner({ available: false }),
+        recovered: pickBanner({ available: true, recovery: { restored_from: 'empty' } }),
+        stopped: pickBanner({ available: true, service_running: false, jobs: inert }),
+        inert: pickBanner({ available: true, service_running: true, jobs: inert }),
+        fine: pickBanner({ available: true, service_running: true, jobs: [] }),
+      }));
+    """)
+    banners = json.loads(out)
+
+    assert banners["unavailable"] == {"kind": "unavailable"}
+    assert banners["recovered"]["kind"] == "recovered"
+    assert banners["recovered"]["restoredFrom"] == "empty"
+    assert banners["stopped"] == {"kind": "stopped"}
+    assert banners["inert"] == {"kind": "inert", "jobs": ["heartbeat"]}
+    assert banners["fine"] is None
+
+
+# ── §5.8 / §4.2: l'heartbeat che non controlla niente ───────────────────────
+
+def test_a_heartbeat_with_no_tasks_is_flagged_even_though_it_says_ok() -> None:
+    out = _run_js("""
+      const view = heartbeatView({
+        file_present: false, file_readable: true, active_task_count: 0,
+        tasks: [], orphan_checks: [],
+      });
+      console.log(JSON.stringify(view));
+    """)
+    view = json.loads(out)
+
+    assert view["checkingNothing"] is True
+    assert view["filePresent"] is False
+    assert view["counts"] == {"total": 0, "broken": 0, "pending": 0}
+
+
+def test_the_three_task_states_are_counted_apart_and_orphans_are_separate() -> None:
+    out = _run_js("""
+      const view = heartbeatView({
+        file_present: true, file_readable: true, active_task_count: 3,
+        tasks: [
+          { id: 'a', state: 'ok' },
+          { id: 'b', state: 'broken', consecutive: 4 },
+          { id: 'c', state: 'pending' },
+        ],
+        orphan_checks: [{ id: 'z', label: 'tolto', consecutive: 9 }],
+      });
+      console.log(JSON.stringify({ counts: view.counts, orphans: view.orphans.length,
+                                   checkingNothing: view.checkingNothing }));
+    """)
+    data = json.loads(out)
+
+    assert data["counts"] == {"total": 3, "broken": 1, "pending": 1}
+    assert data["orphans"] == 1
+    assert data["checkingNothing"] is False
+
+
+# ── il modello completo ─────────────────────────────────────────────────────
+
+def test_the_whole_view_comes_together_for_a_realistic_payload() -> None:
+    out = _run_js("""
+      const payload = {
+        available: true, now_ms: NOW, service_running: true, next_wake_at_ms: NOW + 60_000,
+        default_timezone: 'Europe/Rome', recovery: null,
+        counts: { total: 2, enabled: 2, system: 1, user: 1, inert: 1, broken: 0 },
+        jobs: [
+          {
+            id: 'heartbeat', name: 'heartbeat', kind: 'system', purpose: 'Heartbeat: ...',
+            protected: true, enabled: true, effective: 'inert', mode: 'reminder',
+            one_shot: false, message: null, message_preview: null,
+            display_timezone: 'Europe/Rome',
+            schedule: { kind: 'every', every_ms: 1_800_000 },
+            next_run_at_ms: NOW + 1_800_000, last_run_at_ms: NOW - 60_000,
+            last_status: 'ok', last_error: null,
+            health: { consecutive_could_not_check: 0, since_ms: null, escalated: false },
+            runs: [{ run_at_ms: NOW - 60_000, status: 'ok', duration_ms: 900, error: null }],
+            heartbeat: { file_present: true, file_readable: true, active_task_count: 0,
+                         tasks: [], orphan_checks: [] },
+          },
+          {
+            id: 'ab12', name: 'gocce', kind: 'user', purpose: null, protected: false,
+            enabled: true, effective: 'active', mode: 'monitor', one_shot: false,
+            message: 'testo intero', message_preview: 'testo intero',
+            display_timezone: 'Asia/Tokyo',
+            schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'Asia/Tokyo' },
+            next_run_at_ms: NOW + 600_000, last_run_at_ms: null,
+            last_status: 'silenced', last_error: null,
+            health: { consecutive_could_not_check: 0, since_ms: null, escalated: false },
+            runs: [], heartbeat: null,
+          },
+        ],
+      };
+      const view = buildCronView(payload, { nowMs: NOW, tr, locale: 'it' });
+      console.log(JSON.stringify({
+        banner: view.banner,
+        order: view.rows.map((r) => r.name),
+        heartbeatRow: {
+          health: view.rows[0].health,
+          checkingNothing: view.rows[0].heartbeat.checkingNothing,
+          tzNote: view.rows[0].next.timeZoneNote,
+        },
+        userRow: {
+          monitor: view.rows[1].monitor,
+          tone: view.rows[1].lastTone,
+          tzNote: view.rows[1].next.timeZoneNote,
+          last: view.rows[1].last,
+        },
+        asOf: view.asOf,
+      }));
+    """)
+    view = json.loads(out)
+
+    assert view["banner"] == {"kind": "inert", "jobs": ["heartbeat"]}
+    assert view["order"] == ["heartbeat", "gocce"], "l'inerte viene prima del sano"
+    assert view["heartbeatRow"]["health"] == "inert"
+    assert view["heartbeatRow"]["checkingNothing"] is True
+    assert view["heartbeatRow"]["tzNote"] is None, "Roma su un telefono a Roma e' rumore"
+    assert view["userRow"]["monitor"] is True
+    assert view["userRow"]["tone"] == "neutral", "silenced non e' un fallimento"
+    assert view["userRow"]["tzNote"] == "Asia/Tokyo"
+    assert view["userRow"]["last"] is None, "mai girato: non si inventa una data"
+    assert view["asOf"] == 1_700_000_000_000
+
+
+def test_an_unavailable_payload_still_produces_a_renderable_view() -> None:
+    """Durante l'onboarding la sezione deve dire «non ancora avviato», non
+    esplodere e non restare su «caricamento»."""
+    out = _run_js("""
+      const view = buildCronView({ available: false, now_ms: NOW }, { tr, locale: 'it' });
+      console.log(JSON.stringify(view));
+    """)
+    view = json.loads(out)
+
+    assert view["available"] is False
+    assert view["banner"] == {"kind": "unavailable"}
+    assert view["rows"] == []


### PR DESCRIPTION
## What was missing

The scheduled jobs — four system workers plus the user's own reminders — were readable in exactly two places: by asking Jenny (the `cron` tool's `_list_jobs`, in English, shaped for the model) and by reading logcat on the phone. The WebUI knew about cron in one spot only: `settings_api.py::_cron_recovery_payload`, the notice saying the reminder list had been rebuilt at startup. A warning pointing at a screen that did not exist.

Settings now has a read-only **Scheduling** section, between Background activity and SSH.

## What the panel refuses to take at face value

This is the part worth reviewing, and the reason the change is not just a list renderer.

**A system job survives the setting that created it.** `register_system_job` is idempotent but has no counterpart that deregisters, and `remove_job` protects `system_event`. So switching a worker off leaves its job armed in the store; the handler returns immediately, `_execute_job` takes the normal branch, and the run is recorded as **`ok`**. The heartbeat has its own version of this: enabled, armed, and `HEARTBEAT.md` with no active tasks — `_run_heartbeat` logs at DEBUG and returns `None`. On this phone logcat does not show D lines, so that state had no trace anywhere.

In both cases the store says `ok` and the truth is "does nothing, punctually". So `webui_cron_payload` **reconciles** the store against the config and, for the heartbeat, against the task file, and each job carries `effective: active | inert | disabled`. A banner names the inert ones.

The config is read **from disk** (`load_config()`), not from a captured `Config` — the same reason the four gates in `runtime/cron_dispatch.py` read it from disk: the container's `Config` is photographed at construction and nothing updates it. A panel comparing against the photograph would report "active" for a worker the user had just switched off, reintroducing one layer up the staleness those gates removed.

The four flag paths are not symmetric and are copied from where the real gates read them: `agents.defaults.dream.enabled`, `agents.defaults.gardener.enabled`, `gateway.heartbeat.enabled`, `updates.enabled`.

## Four things a naive viewer gets wrong

Each has a test.

- **`list_jobs()` filters disabled jobs by default.** With the default, a disabled job is indistinguishable from a deleted one — and "did I disable it or delete it?" is one of the questions the panel exists for. `include_disabled=True`, always.
- **`next_run_at_ms` is stored, not computed.** It is recalculated at startup and after each run, so with the scheduler stopped — or right after a long doze — the stored value is in the past. It renders as **overdue**, not as "next run: yesterday at 22:30", which would look like a bug in the panel.
- **`silenced` is not a failure.** A monitor that stayed quiet looked and had nothing to report. Colouring it red teaches the user to ignore colours; and `could_not_check` stays visually distinct from `error`, because collapsing them erases the distinction that third state was introduced for.
- **The heartbeat's `task_checks` map only holds *broken* checks** (absent = healthy). Joined by id with the tasks parsed out of `HEARTBEAT.md`, which is the only way to get a complete view: the file says which checks exist, the store says which are failing. An entry with no task left in the file becomes an `orphan_check` — shown apart, because listing it as broken would accuse the user of a check they removed, and hiding it would leave the job-level counters with no visible cause.

## The decisions

- **Read-only, deliberately.** The `cron` tool is already the single writer on `jobs.json` (plus `action.jsonl` for cross-instance merge), and a second writer from another surface is the failure mode `config/store.py::mutate` documents. A "run now" button (`run_job(force=True)`) would queue a real agent turn — spending tokens, possibly sending a message — from a panel opened to look at something.
- **One endpoint, history included.** The store is a single file, already parsed to build the list; splitting the runs out would cost a second read and a second lock for no gain. `run_history` is capped at 20 by the service, so a phone with ten jobs carries about 10 kB — and the detail dialog opens with no loading state.
- **`workspace/cron/runs/` is not read.** Those 500 records are an internal audit trail carrying `rendered_prompt` and `response` in full. Putting them behind a UI is a privacy decision, not an added detail, and `run_history` already answers "how did it go lately". A test asserts those fields never appear anywhere in the serialised payload — asserted on the JSON, not on known field names, so it survives a field added later.
- **The schedule travels structured, not as a sentence.** `{kind, every_ms, expr, at_ms, tz}`, with the phrase composed client-side: the tool's `_format_timing` produces English for the model, this surface is bilingual. Singular/plural is two i18n keys chosen in the pure module, because `i18n.t` interpolates and does not pluralise, and "1 minuti" reads wrong on every row.
- **Times in the job's own timezone.** `schedule.tz or default`, per job — the same choice as `CronTool._display_timezone` — so the panel and what Jenny says in chat never disagree. The zone is named only when it differs from the device's.
- **No polling.** On a phone where scheduled work is kept punctual through hours of deep doze, a panel that wakes the gateway every few seconds would undo that. It reads once when the section expands, plus the Refresh button, and an "as of HH:MM" stamp declares it is a snapshot. The section force-opens when there is something to say — the same argument as the battery card.
- **Formatting lives in a pure module.** `shared/cron-view.js` has no DOM, no `window`, no i18n import (`tr` is passed in), so the states that cannot be fabricated on a phone — a stopped scheduler, a past due time, a worker switched off — are provable under node. Same idiom as `shared/launcher-rank.js`.

## A defect found on the way in

`CronTool._system_job_purpose` knew three system jobs; `GatewayContainer.build` registers **four**. The gardener had never been added, so asking for the job list it introduced itself as *"System-managed internal job."* while having `docs/using/gardener.md` to its name. The table moves to `jenny/cron/purposes.py` and `tests/cron/test_system_job_purposes.py` compares it against the ids `container.py` actually registers — red before the fix, verified by removing the line again.

## What the phone said

Titan 2, signed release APK, the real gateway reached over `adb forward`:

- `GET /api/webui/cron` returned 8 jobs, `service_running: true`, no recovery, nothing inert.
- Emptying the active section of `HEARTBEAT.md` (by truncation, so inode and MLS label survive) left the job recording `last_status: ok` — twenty consecutive `ok` runs in the detail — and the panel contradicted them: `effective: inert`, `active_task_count: 0`, and the banner *"L'heartbeat gira ogni 30 minuti ma HEARTBEAT.md non ha task attivi: non sta controllando niente."* Restored byte-identical afterwards (`md5 328d9594…`, label intact).
- Looking at the screen found a defect the tests could not: **"Ultima: 1.9 ore fa"** on an Italian phone. The number was interpolated raw; it now goes through `Intl.NumberFormat(locale)`. The suite asserted which i18n key was chosen, never the number inside it.

## Tests

57 new, all green on 3.14 and on the device's 3.11:

- `tests/webui/test_cron_api.py` (26) — the inert cases per worker, the heartbeat join with broken/pending/orphan, disabled jobs present, timezone per job, no prompt or response in the payload, config read from disk.
- `tests/webui/test_cron_view_client.py` (18, under node) — the five outcomes' tones, overdue, the now-window boundaries, the locale decimal separator, ordering (broken first, disabled last), banner precedence.
- `tests/webui/test_cron_routes.py` (8) — 401 without a token, `None` on a foreign path, 200 with `available: false` during onboarding, 500 instead of a traceback, and that the payload is built off the event loop.
- `tests/cron/test_system_job_purposes.py` (5) — the purposes table, both directions, with a guard on its own AST reader.

Full suite 9,323 passed / 7 skipped. `ruff` clean, `pyright` 0 on the blocking subset. Verified in an isolated worktree so the branch is provably self-contained.

Docs: a `## Scheduling` section in `docs/reference/settings.md` and two paragraphs in `docs/using/scheduling.md` — existing files only, so no new public URL on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
